### PR TITLE
Add test and lint jobs to GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,14 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+
+  lint:
+    uses: ./.github/workflows/lint.yaml
+
   build-and-push:
+    needs: [test, lint]
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
- Introduced separate jobs for testing and linting in the release workflow.
- Updated the build-and-push job to depend on the completion of the test and lint jobs.