### PR TITLE
feat: add progress reporting to remove-empty-dirs

### DIFF
--- a/internal/command/tools_remove_empty_dirs.go
+++ b/internal/command/tools_remove_empty_dirs.go
@@ -19,8 +19,13 @@ func newToolsRemoveEmptyDirsCmd() *cobra.Command {
 				return fmt.Errorf("get working directory: %w", err)
 			}
 
-			progress := func(checked, total int) {
-				fmt.Fprintf(os.Stderr, "\rChecking directories: %d/%d", checked, total)
+			progress := library.RemoveEmptyDirsProgress{
+				OnDiscover: func(found int) {
+					fmt.Fprintf(os.Stderr, "\rDiscovering directories: %d", found)
+				},
+				OnCheck: func(checked, total int) {
+					fmt.Fprintf(os.Stderr, "\rChecking directories: %d/%d", checked, total)
+				},
 			}
 
 			count, err := library.RemoveEmptyDirs(cwd, progress)

--- a/internal/command/tools_remove_empty_dirs.go
+++ b/internal/command/tools_remove_empty_dirs.go
@@ -19,7 +19,12 @@ func newToolsRemoveEmptyDirsCmd() *cobra.Command {
 				return fmt.Errorf("get working directory: %w", err)
 			}
 
-			count, err := library.RemoveEmptyDirs(cwd)
+			progress := func(checked, total int) {
+				fmt.Fprintf(os.Stderr, "\rChecking directories: %d/%d", checked, total)
+			}
+
+			count, err := library.RemoveEmptyDirs(cwd, progress)
+			fmt.Fprintln(os.Stderr) // newline after progress
 			if err != nil {
 				return fmt.Errorf("remove empty dirs: %w", err)
 			}

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -94,7 +94,7 @@ func (imp *Importer) ImportDir(sourceDir string) (*Result, error) {
 	for i, g := range groups {
 		stats := fmt.Sprintf("new:%d skipped:%d dropped:%d %s",
 			result.Imported, result.Skipped, result.Dropped, logging.FormatBytes(result.ProcessedBytes))
-		imp.logger.ProgressWithStats(i+1, total, stats, g.Path)
+		imp.logger.ProgressWithStats(i+1, total, "", stats, g.Path)
 
 		if info, err := os.Stat(g.Path); err == nil {
 			result.ProcessedBytes += info.Size()

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -97,7 +97,7 @@ func TestEndToEnd_ImportThenVerify(t *testing.T) {
 	assert.Equal(t, 1, result2.Skipped, "re-import should skip the duplicate")
 
 	// 8. RemoveEmptyDirs → assert 0 removed
-	removed, err := library.RemoveEmptyDirs(libDir)
+	removed, err := library.RemoveEmptyDirs(libDir, library.RemoveEmptyDirsProgress{})
 	require.NoError(t, err)
 	assert.Equal(t, 0, removed, "no empty dirs expected in a populated library")
 

--- a/internal/library/library.go
+++ b/internal/library/library.go
@@ -112,13 +112,22 @@ func ListProcessedDirs(yearDir string) ([]string, error) {
 	return dirs, nil
 }
 
-// RemoveEmptyDirsProgress is called during RemoveEmptyDirs to report progress.
-// It receives the number of directories checked so far and the total to check.
-type RemoveEmptyDirsProgress func(checked, total int)
+// RemoveEmptyDirsProgress reports progress during RemoveEmptyDirs.
+type RemoveEmptyDirsProgress struct {
+	// OnDiscover is called during directory discovery with the count found so far.
+	OnDiscover func(found int)
+	// OnCheck is called during the check/remove phase with checked and total counts.
+	OnCheck func(checked, total int)
+}
 
 // RemoveEmptyDirs walks bottom-up and removes directories that contain only OS junk files
 // or nothing. Returns count of directories removed.
-func RemoveEmptyDirs(root string, progressFn ...RemoveEmptyDirsProgress) (int, error) {
+func RemoveEmptyDirs(root string, progress ...RemoveEmptyDirsProgress) (int, error) {
+	var p RemoveEmptyDirsProgress
+	if len(progress) > 0 {
+		p = progress[0]
+	}
+
 	// Collect all directories
 	var allDirs []string
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
@@ -130,6 +139,9 @@ func RemoveEmptyDirs(root string, progressFn ...RemoveEmptyDirsProgress) (int, e
 		}
 		if d.IsDir() && path != root {
 			allDirs = append(allDirs, path)
+			if p.OnDiscover != nil {
+				p.OnDiscover(len(allDirs))
+			}
 		}
 		return nil
 	})
@@ -140,16 +152,11 @@ func RemoveEmptyDirs(root string, progressFn ...RemoveEmptyDirsProgress) (int, e
 	// Sort reverse so deepest dirs come first
 	sort.Sort(sort.Reverse(sort.StringSlice(allDirs)))
 
-	var cb RemoveEmptyDirsProgress
-	if len(progressFn) > 0 {
-		cb = progressFn[0]
-	}
-
 	count := 0
 	total := len(allDirs)
 	for i, dir := range allDirs {
-		if cb != nil {
-			cb(i+1, total)
+		if p.OnCheck != nil {
+			p.OnCheck(i+1, total)
 		}
 		empty, err := isDirEffectivelyEmpty(dir)
 		if err != nil {

--- a/internal/library/library.go
+++ b/internal/library/library.go
@@ -122,11 +122,7 @@ type RemoveEmptyDirsProgress struct {
 
 // RemoveEmptyDirs walks bottom-up and removes directories that contain only OS junk files
 // or nothing. Returns count of directories removed.
-func RemoveEmptyDirs(root string, progress ...RemoveEmptyDirsProgress) (int, error) {
-	var p RemoveEmptyDirsProgress
-	if len(progress) > 0 {
-		p = progress[0]
-	}
+func RemoveEmptyDirs(root string, p RemoveEmptyDirsProgress) (int, error) {
 
 	// Collect all directories
 	var allDirs []string

--- a/internal/library/library.go
+++ b/internal/library/library.go
@@ -112,9 +112,13 @@ func ListProcessedDirs(yearDir string) ([]string, error) {
 	return dirs, nil
 }
 
+// RemoveEmptyDirsProgress is called during RemoveEmptyDirs to report progress.
+// It receives the number of directories checked so far and the total to check.
+type RemoveEmptyDirsProgress func(checked, total int)
+
 // RemoveEmptyDirs walks bottom-up and removes directories that contain only OS junk files
 // or nothing. Returns count of directories removed.
-func RemoveEmptyDirs(root string) (int, error) {
+func RemoveEmptyDirs(root string, progressFn ...RemoveEmptyDirsProgress) (int, error) {
 	// Collect all directories
 	var allDirs []string
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
@@ -136,8 +140,17 @@ func RemoveEmptyDirs(root string) (int, error) {
 	// Sort reverse so deepest dirs come first
 	sort.Sort(sort.Reverse(sort.StringSlice(allDirs)))
 
+	var cb RemoveEmptyDirsProgress
+	if len(progressFn) > 0 {
+		cb = progressFn[0]
+	}
+
 	count := 0
-	for _, dir := range allDirs {
+	total := len(allDirs)
+	for i, dir := range allDirs {
+		if cb != nil {
+			cb(i+1, total)
+		}
 		empty, err := isDirEffectivelyEmpty(dir)
 		if err != nil {
 			return count, err

--- a/internal/library/library_test.go
+++ b/internal/library/library_test.go
@@ -242,6 +242,32 @@ func TestRemoveEmptyDirsDeepNesting(t *testing.T) {
 	assert.DirExists(t, dir)
 }
 
+func TestRemoveEmptyDirsOuterBecomesEmpty(t *testing.T) {
+	dir := t.TempDir()
+	// outer contains only inner (which is empty) — both should be removed
+	makeDir(t, dir, "outer/inner")
+
+	count, err := RemoveEmptyDirs(dir)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+	assert.NoDirExists(t, filepath.Join(dir, "outer"))
+}
+
+func TestRemoveEmptyDirsProgress(t *testing.T) {
+	dir := t.TempDir()
+	makeDir(t, dir, "a/b")
+	makeDir(t, dir, "c")
+
+	var calls []int
+	progress := func(checked, total int) {
+		calls = append(calls, checked)
+	}
+
+	_, err := RemoveEmptyDirs(dir, progress)
+	require.NoError(t, err)
+	assert.Equal(t, []int{1, 2, 3}, calls)
+}
+
 func TestIsDirEffectivelyEmptyOnlyOSFiles(t *testing.T) {
 	dir := t.TempDir()
 	makeDir(t, dir, "junkdir")

--- a/internal/library/library_test.go
+++ b/internal/library/library_test.go
@@ -258,14 +258,21 @@ func TestRemoveEmptyDirsProgress(t *testing.T) {
 	makeDir(t, dir, "a/b")
 	makeDir(t, dir, "c")
 
-	var calls []int
-	progress := func(checked, total int) {
-		calls = append(calls, checked)
+	var discovered []int
+	var checked []int
+	p := RemoveEmptyDirsProgress{
+		OnDiscover: func(found int) {
+			discovered = append(discovered, found)
+		},
+		OnCheck: func(ch, total int) {
+			checked = append(checked, ch)
+		},
 	}
 
-	_, err := RemoveEmptyDirs(dir, progress)
+	_, err := RemoveEmptyDirs(dir, p)
 	require.NoError(t, err)
-	assert.Equal(t, []int{1, 2, 3}, calls)
+	assert.Equal(t, []int{1, 2, 3}, discovered)
+	assert.Equal(t, []int{1, 2, 3}, checked)
 }
 
 func TestIsDirEffectivelyEmptyOnlyOSFiles(t *testing.T) {

--- a/internal/library/library_test.go
+++ b/internal/library/library_test.go
@@ -104,7 +104,7 @@ func TestRemoveEmptyDirs(t *testing.T) {
 	makeDir(t, dir, "a/b/d")
 	makeFile(t, dir, "a/keep.txt", "data")
 
-	count, err := RemoveEmptyDirs(dir)
+	count, err := RemoveEmptyDirs(dir, RemoveEmptyDirsProgress{})
 	require.NoError(t, err)
 	assert.Greater(t, count, 0)
 
@@ -119,7 +119,7 @@ func TestRemoveEmptyDirsIgnoresOSFiles(t *testing.T) {
 	makeDir(t, dir, "empty-with-junk")
 	makeFile(t, dir, "empty-with-junk/.DS_Store", "junk")
 
-	count, err := RemoveEmptyDirs(dir)
+	count, err := RemoveEmptyDirs(dir, RemoveEmptyDirsProgress{})
 	require.NoError(t, err)
 	assert.Greater(t, count, 0)
 	assert.NoDirExists(t, filepath.Join(dir, "empty-with-junk"))
@@ -203,7 +203,7 @@ func TestRemoveEmptyDirsNoEmptyDirs(t *testing.T) {
 	makeFile(t, dir, "a/file.txt", "data")
 	makeFile(t, dir, "b/file.txt", "data")
 
-	count, err := RemoveEmptyDirs(dir)
+	count, err := RemoveEmptyDirs(dir, RemoveEmptyDirsProgress{})
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
 }
@@ -234,7 +234,7 @@ func TestRemoveEmptyDirsDeepNesting(t *testing.T) {
 	dir := t.TempDir()
 	makeDir(t, dir, "a/b/c/d/e")
 
-	count, err := RemoveEmptyDirs(dir)
+	count, err := RemoveEmptyDirs(dir, RemoveEmptyDirsProgress{})
 	require.NoError(t, err)
 	// All empty nested dirs should be removed
 	assert.Equal(t, 5, count)
@@ -247,7 +247,7 @@ func TestRemoveEmptyDirsOuterBecomesEmpty(t *testing.T) {
 	// outer contains only inner (which is empty) — both should be removed
 	makeDir(t, dir, "outer/inner")
 
-	count, err := RemoveEmptyDirs(dir)
+	count, err := RemoveEmptyDirs(dir, RemoveEmptyDirsProgress{})
 	require.NoError(t, err)
 	assert.Equal(t, 2, count)
 	assert.NoDirExists(t, filepath.Join(dir, "outer"))
@@ -317,7 +317,7 @@ func TestRemoveEmptyDirsPermissionError(t *testing.T) {
 
 	// RemoveEmptyDirs will encounter a permission error when checking restricted/
 	// Some dirs may be removed before the error
-	_, err := RemoveEmptyDirs(dir)
+	_, err := RemoveEmptyDirs(dir, RemoveEmptyDirsProgress{})
 	assert.Error(t, err)
 }
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -75,8 +75,8 @@ func (l *Logger) Progress(current, total int, currentFile string) {
 	}
 }
 
-// ProgressWithStats displays progress with an arbitrary stats string.
-func (l *Logger) ProgressWithStats(current, total int, stats, currentFile string) {
+// ProgressWithStats displays progress with an optional prefix and an arbitrary stats string.
+func (l *Logger) ProgressWithStats(current, total int, prefix, stats, currentFile string) {
 	pct := 0
 	if total > 0 {
 		pct = current * 100 / total
@@ -85,9 +85,9 @@ func (l *Logger) ProgressWithStats(current, total int, stats, currentFile string
 	defer l.mu.Unlock()
 	if l.isTTY {
 		file := truncate(currentFile, 40)
-		_, _ = fmt.Fprintf(l.stderr, "\r\033[K[%d%%] %s/%s %s %s", pct, FormatNumber(current), FormatNumber(total), stats, file)
+		_, _ = fmt.Fprintf(l.stderr, "\r\033[K%s[%d%%] %s/%s %s %s", prefix, pct, FormatNumber(current), FormatNumber(total), stats, file)
 	} else {
-		_, _ = fmt.Fprintf(l.stderr, "[progress] %s/%s (%d%%) %s\n", FormatNumber(current), FormatNumber(total), pct, stats)
+		_, _ = fmt.Fprintf(l.stderr, "[progress] %s%s/%s (%d%%) %s\n", prefix, FormatNumber(current), FormatNumber(total), pct, stats)
 	}
 }
 

--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -80,7 +80,7 @@ func (v *Verifier) Verify() (*Result, error) {
 		}
 	}
 
-	for _, year := range years {
+	for i, year := range years {
 		yearDir := filepath.Join(v.cfg.LibraryPath, year)
 
 		// Validate year level — only sources/ and processed/ allowed
@@ -94,7 +94,7 @@ func (v *Verifier) Verify() (*Result, error) {
 		}
 
 		// Validate individual source files
-		if err := v.verifySourceFiles(yearDir, year, result); err != nil {
+		if err := v.verifySourceFiles(yearDir, year, i+1, len(years), result); err != nil {
 			return result, err
 		}
 	}
@@ -103,7 +103,7 @@ func (v *Verifier) Verify() (*Result, error) {
 }
 
 // verifySourceFiles checks each file in sources/ for correct path and hash.
-func (v *Verifier) verifySourceFiles(yearDir, year string, result *Result) error {
+func (v *Verifier) verifySourceFiles(yearDir, year string, yearIdx, yearTotal int, result *Result) error {
 	files, err := library.ListSourceFiles(yearDir)
 	if err != nil {
 		return fmt.Errorf("list source files for %s: %w", year, err)
@@ -117,9 +117,10 @@ func (v *Verifier) verifySourceFiles(yearDir, year string, result *Result) error
 
 	total := len(files)
 	for i, filePath := range files {
+		prefix := fmt.Sprintf("[%s %d/%d] ", year, yearIdx, yearTotal)
 		stats := fmt.Sprintf("valid:%d fixed:%d inconsistent:%d %s",
 			result.Verified, result.Fixed, result.Inconsistent, logging.FormatBytes(result.ProcessedBytes))
-		v.logger.ProgressWithStats(i+1, total, stats, filePath)
+		v.logger.ProgressWithStats(i+1, total, prefix, stats, filePath)
 
 		if info, err := os.Stat(filePath); err == nil {
 			result.ProcessedBytes += info.Size()


### PR DESCRIPTION
## Summary
- Add progress callback to `RemoveEmptyDirs` showing `Checking directories: N/M` during execution
- Verify cascading removal works correctly (outer dir removed after its only child is removed)
- Add tests for progress callback and nested empty dir cascading

## Test plan
- [x] `TestRemoveEmptyDirsOuterBecomesEmpty` — confirms outer dir is removed after inner empty dir is removed
- [x] `TestRemoveEmptyDirsProgress` — confirms progress callback fires for each directory checked
- [x] All existing `RemoveEmptyDirs` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)