### PR TITLE
feat: per-year verification cache for crash-safe verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ imv verify [flags]
 | `--year YYYY` | Only verify files from this year |
 | `--no-fail-fast` | Continue on errors |
 | `--no-randomize` | Verify in directory order |
+| `--no-cache` | Skip the per-year verification cache (don't read or write it) |
 | `--hash-algo` | `md5` (default) or `sha256` |
+
+Verify keeps a per-year cache at `<year>/.imv/verify.cache` so repeated runs can skip files whose size and mtime are unchanged since the last successful verification. The cache survives crashes and power loss (appends are fsynced every 10 s; compaction is atomic). It is invalidated when files are copied without preserving mtime — use `rsync -a` or `cp -p` when migrating a library. To force a full re-verify of a year, delete its cache file or pass `--no-cache`.
 
 ### tools
 

--- a/docs/superpowers/specs/2026-04-19-verify-cache-design.md
+++ b/docs/superpowers/specs/2026-04-19-verify-cache-design.md
@@ -1,0 +1,319 @@
+# Verify Cache — Design
+
+**Date:** 2026-04-19
+**Status:** Approved, ready for planning
+**Scope:** `imv verify` command — adds a persistent cache of already-verified files so repeated verifications of a large library (~5 TB) can skip the expensive exiftool-and-hash work for files that have not changed since last verification. Primary motivation: resumability after power loss or interruption, so a multi-hour verify does not start over.
+
+## Goals
+
+- Make repeated `verify` runs over an unchanged library fast: O(tree-walk + stat + structural-checks) instead of O(read-every-byte).
+- Survive crashes and power loss: previously-verified entries must not be lost even if the process dies mid-run.
+- Zero new dependencies and zero binary-size bloat.
+- Fail-soft: any cache malfunction degrades to a full re-verification; correctness of `verify` itself is never compromised by cache state.
+
+## Non-goals
+
+- Caching fast-mode (`--fast`) verification results. Fast mode only checks filename format; caching it would be misleading and the speedup is negligible.
+- Caching structural checks (year-level contents, device-dir name validity). These run on `ReadDir` output and cost effectively nothing.
+- Caching files under `processed/` or `sources-manual/`. Verify does not inspect them today.
+- Caching `import` command output. Import already avoids double-hashing the source file (see commit 0850e5d); its speedup comes from a different mechanism.
+- A cross-filesystem "move with mtime preserved" guarantee. We document the constraint and accept that plain `cp -r` invalidates the cache (full re-verify then rebuilds it).
+
+## Key design decisions
+
+### 1. Per-year caches, colocated with year data
+
+One cache file per year directory, at `<library>/<year>/.imv/verify.cache`.
+
+Rationale:
+- The library is already partitioned by year at the top level. Every source file belongs to exactly one year.
+- The verifier's existing loop is year-by-year. Cache load + compaction can happen at the top of each year's iteration, reusing the same `ListSourceFiles` walk — no extra pre-walk across the whole library.
+- `--year YYYY` naturally scopes cache I/O: other years' caches are not opened or loaded.
+- Smaller individual files (~10 MB per year for a 5 TB library) mean faster compaction and smaller memory footprint: only one year's cache is resident at a time.
+- Corruption in one year's cache cannot affect another year's.
+- Rsyncing a single year folder between machines carries its cache along.
+
+### 2. Append-only plain text, with startup compaction
+
+Format: UTF-8, newline-terminated lines, tab-separated fields. Lines starting with `#` are comments (ignored on read).
+
+```
+# imv verify-cache v1 — path\tsize\tmtime_ns\thash_algo\tverified_at_unix
+# Invalidated when files are copied without preserving mtime. Use rsync -a
+# or cp -p to preserve mtime across filesystem migrations.
+sources/Apple iPhone 15 Pro (image)/2024-08-20/2024-08-20_18-45-03_a1b2c3d4.jpg	5242880	1724180703123456789	md5	1744934400
+```
+
+Fields per record:
+- **path** — forward-slash path relative to the year directory (not the library root; since one file per year, the relative-to-year path is unique within the cache and shorter).
+- **size** — bytes (`os.FileInfo.Size()`).
+- **mtime_ns** — `os.FileInfo.ModTime().UnixNano()`.
+- **hash_algo** — `md5` or `sha256`. Stored per entry so switching algorithms invalidates entries.
+- **verified_at_unix** — unix seconds when the record was written. Informational only (useful for debugging); not consulted during matching.
+
+Path escape rules: filenames in this project follow `YYYY-MM-DD_HH-MM-SS_<hash>.<ext>` and never contain `\t` or `\n`. Device dir names (`<Make> <Model> (<type>)`) are also free of these characters. We defensively reject any path containing `\t` or `\n` during `AppendVerified` — log a warning and treat as uncacheable rather than corrupting the log.
+
+SQLite and bbolt were considered and rejected: single-writer sequential-append workload, no query requirements, and no desire to take on a cgo dependency or pure-Go SQLite's binary-size cost.
+
+### 3. Cache hit semantics
+
+A hit requires **all four** to match:
+- Same relative path (file exists where the cache says it should)
+- Same `size`
+- Same `mtime_ns`
+- Same `hash_algo` as the current run's config
+
+On hit: skip the expensive `ext.Extract()` call (exiftool spawn + full-file content hash) and the expected-path comparison. Count as `Verified`.
+
+On hit, **still run** the cheap per-file structural checks that already exist in the loop:
+- `defaults.IsIgnoredFile` / sidecar extension skip
+- Filename-date-matches-date-dir check
+- Date-dir-year-matches-year-level check
+
+These are string operations on already-walked directory entries and cost essentially nothing.
+
+On miss: run the existing full-verify path. If the outcome is `Verified` (path matched expected), append a new cache entry. If the outcome is `Fixed`, `Inconsistent`, or `Error`, **do not write to the cache** — the cache is strictly "what has been verified" and fixes are rare enough that re-verifying them on the next run is acceptable.
+
+### 4. Startup lifecycle (per year)
+
+At the top of each year's iteration in `Verify()`:
+
+1. If `--no-cache` or `--fast`: skip all cache setup; proceed as today.
+2. `mkdir -p <year>/.imv/` (mode `0755`). If this fails, log a warning, skip cache for this year, continue.
+3. `Load(<year>/.imv/verify.cache)`:
+   - Missing file → empty cache (not an error).
+   - Parse line-by-line. Skip comments. Dedupe by path (last occurrence wins). Skip malformed lines with a debug warning.
+4. Walk year's source files via `library.ListSourceFiles(yearDir)` and `os.Stat` each. Build `[]FileEntry` (preserving list order, for randomization downstream) where each entry holds `{absPath, relPath, FileInfo}`. This list becomes the single source of truth for this year: it feeds both cache intersection here and the subsequent `verifySourceFiles` loop (which, today, calls `ListSourceFiles` + `os.Stat` itself — we lift that work up so it happens exactly once). When the cache is disabled, the pre-walk still happens so the loop has a uniform data source.
+5. **Intersect:** for every cache entry whose `relPath` exists in the pre-walked set AND whose `size + mtime_ns + hash_algo` match the current `FileInfo` + config, add to `keep` map. Entries not in `keep` are stale (file moved, modified, deleted, or algo changed).
+6. `Compact(keep)`:
+   - Write `<year>/.imv/verify.cache.tmp` with header + `keep` entries.
+   - `file.Sync()` on the tmp file.
+   - `os.Rename(tmp, final)` — atomic on POSIX. If rename fails, remove the tmp file and proceed with caching disabled for this year.
+7. Reopen the compacted cache file with `O_APPEND | O_WRONLY` for subsequent writes. Wrap with `bufio.Writer`. Record `lastFlush = time.Now()`.
+
+**Crash between steps 6 and 7:** the atomic rename has already completed; the cache is in a clean state. Next run resumes from the compacted cache.
+
+**Crash during step 6 (before rename):** the tmp file is incomplete or missing; the original cache is untouched. Next run re-parses it and re-compacts.
+
+### 5. Per-file lifecycle (inside the verify loop)
+
+```
+for each file in year's pre-walked source files:
+    result.ProcessedBytes += fi.Size()       // uses pre-walked FileInfo, no re-stat
+    run cheap structural checks (ignored, sidecar, filename-date-matches-date-dir)
+    if structural check failed:
+        continue                              # (increments Inconsistent/Errors as today)
+
+    if cache enabled AND entry in cache AND Matches(entry, fi, algo):
+        result.Verified++
+        result.CacheHits++
+        continue                              # skip ext.Extract + path rebuild
+
+    md, err := ext.Extract(filePath, hasher)
+    ... (existing metadata/path-build logic) ...
+    if absActual == absExpected:
+        result.Verified++
+        cache.AppendVerified(entry)           # best-effort; nil-safe; errors logged, non-fatal
+    else:
+        result.Inconsistent++
+        if cfg.Fix:
+            transfer.TransferFile(filePath, expectedPath, Move)
+            result.Fixed++
+            # deliberately NOT caching fixed files (see section 8)
+```
+
+After each file, check `time.Since(lastFlush)`. If `> 10s`, call `Flush()`:
+- `bufio.Writer.Flush()`
+- `file.Sync()` (fsync)
+- `lastFlush = time.Now()`
+
+Worst-case data loss on hard crash: ~10 seconds of appended entries.
+
+### 6. End-of-year and end-of-run cleanup
+
+At end of each year's iteration: `Close()` — flush buffered writes, fsync, close file. Defer-based so it runs on early returns/errors.
+
+At end of `Verify()`: all year caches are already closed.
+
+### 7. Signal handling
+
+On `SIGINT` or `SIGTERM`, the verifier closes whatever year cache is currently open and exits with code 130. Implementation: the verifier holds a pointer to the currently-open cache in a field; a signal handler installed at the start of `Verify()` reads that pointer, calls `Close()` (nil-safe), and calls `os.Exit(130)`.
+
+This is best-effort — if the flush itself fails, we exit anyway without blocking on retry. Any appends already flushed before the signal are safe.
+
+### 8. Fix interaction
+
+Fixes do **not** write to the cache. Rationale given by the user: the cache is a verification cache, so it should only record read-and-confirmed work, not side-effect work.
+
+Concretely:
+- If `verify --fix` moves a misplaced file, no entry is appended for the new location.
+- The file's entry (at its old location, if it had one) is already absent from the intersection result because the old path no longer exists on disk after the move. Compaction on next startup will confirm this.
+- The moved file gets fully re-verified on the next run and will be added to the cache then.
+
+Fixes are rare; the cost of re-verifying one file next time is negligible.
+
+### 9. Interaction with existing structural validation
+
+`verifyYearLevel` currently allows only `sources/`, `processed/`, `sources-manual/` as children of a year directory. Add `.imv` to the allowed set so the cache's home directory does not trigger "unexpected directory" warnings.
+
+`internal/defaults/defaults.go` — extend `IsIgnoredFile` to return `true` for any file whose extension is `.cache` (in addition to the existing static set of OS-junk filenames). This is defensive: it keeps any `.cache` file from flagging as unexpected if it ever ends up outside `.imv/`, and matches the naming convention we're adopting for the cache file itself.
+
+### 10. Flag
+
+Add `--no-cache` to the `verify` command. Default: off (cache enabled).
+
+Behavior when set: no cache file is read, no cache file is written, no `.imv/` directory is created for the run. Existing cache files are left untouched on disk. Useful for debugging.
+
+No `--rebuild-cache` flag. Equivalent effect is achieved by deleting the relevant cache file(s) before running; this is simpler and more transparent.
+
+## Implementation layout
+
+### New code
+
+**`internal/verifier/cache.go`** — the cache package. Kept in the `verifier` package rather than a separate package because the cache is a private implementation detail of verify; no other consumer is anticipated. Types:
+
+```go
+type Entry struct {
+    RelPath    string
+    Size       int64
+    MtimeNs    int64
+    HashAlgo   string
+    VerifiedAt int64
+}
+
+type Cache struct {
+    // path to the on-disk cache file for this year
+    path      string
+    // relPath → entry, populated at Load time, consulted by Lookup
+    entries   map[string]Entry
+    // open file handle for appends after Compact completes; nil if disabled
+    file      *os.File
+    buf       *bufio.Writer
+    lastFlush time.Time
+}
+
+func Load(path string) (*Cache, error)
+func (c *Cache) Lookup(relPath string) (Entry, bool)
+func (c *Cache) Matches(e Entry, fi os.FileInfo, algo string) bool
+func (c *Cache) Compact(keep map[string]Entry) error
+func (c *Cache) AppendVerified(e Entry) error
+func (c *Cache) Flush() error
+func (c *Cache) Close() error
+```
+
+All methods are nil-safe so callers in `verifier.go` do not need to check before calling (failure modes already produce a nil `*Cache` so the happy path and the degraded path share the same call sites).
+
+### Modified code
+
+**`internal/verifier/verifier.go`:**
+- Add `NoCache bool` to `Config`.
+- Add `CacheHits int` to `Result`.
+- Add a field holding the currently-open year cache so the signal handler can reach it.
+- Introduce a small `FileEntry` struct (`AbsPath`, `RelPath`, `os.FileInfo`) representing one pre-walked source file.
+- In `Verify()`: install signal handler at start; per-year walk-and-stat once into `[]FileEntry`; `openYearCache()` consumes that slice to build the intersection and compact; `defer cache.Close()`; pass the slice into `verifySourceFiles`.
+- Change `verifySourceFiles` signature from `(yearDir, year string, yearIdx, yearTotal int, result *Result)` to `(entries []FileEntry, year string, yearIdx, yearTotal int, yc *cache.Cache, result *Result)`. The loop iterates `entries` directly (no internal `ListSourceFiles` call, no per-file `os.Stat`). Cache `Lookup` happens after cheap structural checks and before `ext.Extract`; `AppendVerified` is called after a successful `Verified` outcome.
+- Progress line updated to include `cached:N`.
+
+**`internal/command/verify.go`:** add `--no-cache` flag wired to `Config.NoCache`.
+
+**`internal/defaults/defaults.go`:** extend `IsIgnoredFile` to match `.cache` extension.
+
+**`internal/defaults/defaults_test.go`:** add test cases for `.cache` extension handling.
+
+**`internal/verifier/verifier.go` structural validation:** add `.imv` to the allowed set in `verifyYearLevel`.
+
+**`README.md`:** document the `--no-cache` flag and the cache file location in the verify section.
+
+## Error handling summary
+
+The cache is a performance optimization, never a correctness gate.
+
+| Failure | Action |
+|---------|--------|
+| `mkdir .imv/` fails | Warn; disable cache for this year; continue verify |
+| Cache file read error | Warn; treat as empty; continue |
+| Malformed line during Load | Skip line; debug-level warning; continue parsing |
+| Compact tmp write fails | Warn; remove tmp if present; disable cache for this year; continue |
+| Compact rename fails | Warn; remove tmp; disable cache for this year; continue |
+| AppendVerified write fails | Warn once per year; disable further appends for this year |
+| Flush/fsync fails | Warn; continue (next flush may succeed) |
+| Signal received mid-flush | Best-effort close; exit 130 regardless |
+
+Verify's exit code is determined solely by `result.Inconsistent` and `result.Errors`.
+
+## Observability
+
+Progress line:
+```
+[2024 1/3] valid:152 cached:148 fixed:0 inconsistent:0 1.2 GB path/to/file.jpg
+```
+
+Per-year debug log emitted after `Compact`:
+```
+cache for 2024: loaded 12,340 entries, 12,100 matched, compacted (dropped 240 stale)
+```
+
+End-of-run summary (adds a row to the existing summary pane): cache hits total vs new entries written.
+
+## Testing
+
+### Unit tests — `internal/verifier/cache_test.go`
+
+- `Load`:
+  - missing file → empty cache, no error
+  - empty file → empty cache
+  - header-only file → empty cache
+  - valid records
+  - duplicate paths → last wins
+  - malformed lines → skipped with warning, valid lines preserved
+  - lines with embedded `\t` or `\n` → rejected
+- `Matches`:
+  - identical stat → true
+  - size differs → false
+  - mtime differs → false
+  - algo differs → false
+- `Compact`:
+  - happy path — new file replaces old, content correct
+  - simulated failure between tmp write and rename — original file intact
+  - keep set empty — resulting file has header only
+- `AppendVerified`:
+  - successful append visible after `Flush`
+  - entry with `\t` in path — rejected, error returned, file unchanged
+- Flush cadence:
+  - two appends within 10s → one fsync (via injected clock)
+  - append after > 10s since last flush → fsync triggered
+- `Close`:
+  - flushes any buffered writes
+  - subsequent calls on closed cache are no-ops (nil-safe)
+- nil receiver:
+  - `(*Cache)(nil).Lookup(...)` returns `Entry{}, false`
+  - `(*Cache)(nil).AppendVerified(...)` returns `nil`
+  - `(*Cache)(nil).Close()` returns `nil`
+
+### Integration tests — extend `internal/integration_test.go`
+
+- First `verify` populates `2024/.imv/verify.cache` — file exists, contents as expected.
+- Second `verify` hits the cache — result counts include `CacheHits`, no exiftool calls are made for cached files (verify via test-double MetadataExtractor), final counts identical to first run.
+- Touch a file's mtime between runs — that one file misses, others hit.
+- Delete a file between runs — compaction drops its entry; cache file shrinks.
+- `--no-cache` run — no cache file created (or a pre-existing one is left untouched).
+- `--fix` flow — misplaced file is moved, no cache entry is written for the new location; on next run without `--fix`, the moved file is re-verified and now appears in the cache.
+- `--year 2024` — only 2024's cache is opened; other years' cache file mtimes unchanged.
+- Algo switch (`--hash-algo md5` then `--hash-algo sha256`) — first run populates with md5; second run treats all entries as misses (algo mismatch); after second run, entries are rewritten with sha256.
+- Cache file containing random binary garbage → Load returns empty cache, warning logged; verify proceeds.
+- `.imv/verify.cache` present at year level does not trigger the "unexpected directory in 2024/" warning.
+- `foo.cache` file placed anywhere in the tree is ignored by structural validation (via `IsIgnoredFile` extension rule).
+
+### Crash-safety test (stretch goal)
+
+Test helper writes a valid record, a partial line (no newline), then reopens with `Load`. Partial line is skipped; valid record is loaded.
+
+## Open items for the plan phase
+
+- Confirm placement of the signal handler — inside `Verify()` vs. in `cmd/imv/verify` command wiring. Likely inside `Verify()` so tests can drive it, but the `os.Exit(130)` call should probably be at the command boundary.
+- Whether to log the cache summary only at `--verbose` level or always. Initial recommendation: always, one line per year at info level, since cache state is load-bearing for understanding run times.
+- Decide whether the 10-second flush threshold is a constant or a tunable. Initial recommendation: constant. If tuning is needed, extract later.
+
+## Rollout
+
+Single commit on a feature branch. No migration concerns — old libraries without `.imv/` directories will have them created on first run; no on-disk data format changes elsewhere.

--- a/internal/command/verify.go
+++ b/internal/command/verify.go
@@ -18,6 +18,7 @@ func newVerifyCmd() *cobra.Command {
 		year        string
 		noFailFast  bool
 		noRandomize bool
+		noCache     bool
 		hashAlgo    string
 	)
 
@@ -48,6 +49,7 @@ func newVerifyCmd() *cobra.Command {
 				Fast:          fast,
 				Randomize:     !noRandomize,
 				YearFilter:    year,
+				NoCache:       noCache,
 			}
 
 			v := verifier.New(cfg, ext, logger)
@@ -58,6 +60,7 @@ func newVerifyCmd() *cobra.Command {
 
 			logger.PrintSummary([]logging.SummaryField{
 				{Label: "Verified", Value: logging.FormatNumber(result.Verified)},
+				{Label: "Cache hits", Value: logging.FormatNumber(result.CacheHits)},
 				{Label: "Inconsistent", Value: logging.FormatNumber(result.Inconsistent)},
 				{Label: "Fixed", Value: logging.FormatNumber(result.Fixed)},
 				{Label: "Errors", Value: logging.FormatNumber(result.Errors)},
@@ -77,6 +80,7 @@ func newVerifyCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&noFailFast, "no-fail-fast", false, "Continue on errors instead of stopping")
 	cmd.Flags().BoolVar(&fast, "fast", false, "Fast mode: validate filenames and structure only, skip hash verification")
 	cmd.Flags().BoolVar(&noRandomize, "no-randomize", false, "Verify files in directory order instead of randomized")
+	cmd.Flags().BoolVar(&noCache, "no-cache", false, "Disable the verification cache for this run (don't read or write .imv/verify.cache)")
 	cmd.Flags().StringVar(&hashAlgo, "hash-algo", defaults.DefaultHashAlgorithm, "Hash algorithm to use (md5, sha256)")
 
 	return cmd

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -3,6 +3,7 @@ package internal_test
 import (
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,9 +19,14 @@ import (
 
 // fakeExtractor implements both importer.MetadataExtractor and
 // verifier.MetadataExtractor (identical interfaces) for testing.
-type fakeExtractor struct{}
+type fakeExtractor struct {
+	// extractCalls counts how many times Extract was invoked — used to verify
+	// cache hits bypass the extractor on repeat runs.
+	extractCalls atomic.Int64
+}
 
 func (f *fakeExtractor) Extract(path string, hasher *defaults.Hasher) (*metadata.FileMetadata, error) {
+	f.extractCalls.Add(1)
 	full, short, err := metadata.ComputeFileHash(path, hasher)
 	if err != nil {
 		return nil, err
@@ -102,4 +108,327 @@ func TestEndToEnd_ImportThenVerify(t *testing.T) {
 	assert.Equal(t, 0, removed, "no empty dirs expected in a populated library")
 
 	// 9. Clean up is automatic via t.TempDir()
+}
+
+// --- Verify cache integration tests ---
+
+// cachedLib imports two files from srcDir into a fresh library and returns
+// the library path, extractor, verifier config factory, and logger for
+// downstream cache-behavior tests.
+func setupCachedLib(t *testing.T) (libDir string, ext *fakeExtractor, logger *logging.Logger) {
+	t.Helper()
+	srcDir := t.TempDir()
+	libDir = t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "a.jpg"), []byte("contents-a"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "b.jpg"), []byte("contents-b-different"), 0o644))
+
+	logger = logging.New(os.Stdout, os.Stderr, false)
+	ext = &fakeExtractor{}
+
+	imp := importer.New(importer.Config{
+		LibraryPath:   libDir,
+		SeparateVideo: false,
+		HashAlgo:      "md5",
+		FailFast:      true,
+	}, ext, logger)
+	_, err := imp.ImportDir(srcDir)
+	require.NoError(t, err)
+	return
+}
+
+func newVerifier(libDir string, ext *fakeExtractor, logger *logging.Logger, noCache bool) *verifier.Verifier {
+	return verifier.New(verifier.Config{
+		LibraryPath:   libDir,
+		SeparateVideo: false,
+		HashAlgo:      "md5",
+		FailFast:      true,
+		NoCache:       noCache,
+	}, ext, logger)
+}
+
+// TestVerifyCache_SecondRunSkipsExtract: first verify populates cache,
+// second verify hits it and doesn't call the extractor at all.
+func TestVerifyCache_SecondRunSkipsExtract(t *testing.T) {
+	libDir, ext, logger := setupCachedLib(t)
+
+	// First run: populates cache.
+	v := newVerifier(libDir, ext, logger, false)
+	r1, err := v.Verify()
+	require.NoError(t, err)
+	assert.Equal(t, 2, r1.Verified)
+	assert.Equal(t, 0, r1.CacheHits, "nothing cached on first run")
+	extractsAfterFirst := ext.extractCalls.Load()
+	assert.Greater(t, extractsAfterFirst, int64(0), "extractor should run on first verify")
+
+	// Cache file should exist for 2024.
+	cachePath := verifier.CacheFilePath(filepath.Join(libDir, "2024"))
+	_, err = os.Stat(cachePath)
+	require.NoError(t, err)
+
+	// Second run: everything should cache-hit.
+	ext.extractCalls.Store(0)
+	v2 := newVerifier(libDir, ext, logger, false)
+	r2, err := v2.Verify()
+	require.NoError(t, err)
+	assert.Equal(t, 2, r2.Verified)
+	assert.Equal(t, 2, r2.CacheHits, "all files should hit cache on second run")
+	assert.Equal(t, int64(0), ext.extractCalls.Load(), "extractor must not run for cached files")
+}
+
+// TestVerifyCache_MtimeMismatchCausesMiss: touching a file changes its mtime
+// and forces a cache miss for that file.
+func TestVerifyCache_MtimeMismatchCausesMiss(t *testing.T) {
+	libDir, ext, logger := setupCachedLib(t)
+
+	v := newVerifier(libDir, ext, logger, false)
+	_, err := v.Verify()
+	require.NoError(t, err)
+
+	// Pick one source file and bump its mtime by 1 hour.
+	files, err := library.ListSourceFiles(filepath.Join(libDir, "2024"))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(files), 2)
+	newMtime := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(files[0], newMtime, newMtime))
+
+	ext.extractCalls.Store(0)
+	v2 := newVerifier(libDir, ext, logger, false)
+	r, err := v2.Verify()
+	require.NoError(t, err)
+	assert.Equal(t, 2, r.Verified)
+	assert.Equal(t, 1, r.CacheHits, "only the unchanged file should hit cache")
+	assert.Equal(t, int64(1), ext.extractCalls.Load(), "extractor runs for the touched file only")
+}
+
+// TestVerifyCache_DeletedFileCompactedOut: a file that existed at
+// cache-write time is deleted before the next run; it drops out of the
+// cache on compaction.
+func TestVerifyCache_DeletedFileCompactedOut(t *testing.T) {
+	libDir, ext, logger := setupCachedLib(t)
+
+	v := newVerifier(libDir, ext, logger, false)
+	_, err := v.Verify()
+	require.NoError(t, err)
+
+	cachePath := verifier.CacheFilePath(filepath.Join(libDir, "2024"))
+	beforeInfo, err := os.Stat(cachePath)
+	require.NoError(t, err)
+
+	// Delete one source file.
+	files, err := library.ListSourceFiles(filepath.Join(libDir, "2024"))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(files), 1)
+	require.NoError(t, os.Remove(files[0]))
+
+	v2 := newVerifier(libDir, ext, logger, false)
+	_, err = v2.Verify()
+	require.NoError(t, err)
+
+	// Cache file should now be smaller (one entry dropped during compaction).
+	afterInfo, err := os.Stat(cachePath)
+	require.NoError(t, err)
+	assert.Less(t, afterInfo.Size(), beforeInfo.Size(), "compaction should shrink cache after delete")
+}
+
+// TestVerifyCache_NoCacheFlag: --no-cache doesn't read or write the cache.
+func TestVerifyCache_NoCacheFlag(t *testing.T) {
+	libDir, ext, logger := setupCachedLib(t)
+
+	v := newVerifier(libDir, ext, logger, true) // noCache=true
+	r, err := v.Verify()
+	require.NoError(t, err)
+	assert.Equal(t, 2, r.Verified)
+	assert.Equal(t, 0, r.CacheHits)
+
+	// No cache file should have been created.
+	cachePath := verifier.CacheFilePath(filepath.Join(libDir, "2024"))
+	_, err = os.Stat(cachePath)
+	assert.True(t, os.IsNotExist(err), "no-cache should not create cache file")
+}
+
+// TestVerifyCache_HashAlgoSwitchInvalidates: switching algos means no entries match.
+func TestVerifyCache_HashAlgoSwitchInvalidates(t *testing.T) {
+	libDir, ext, logger := setupCachedLib(t)
+
+	// Populate cache with md5.
+	v := newVerifier(libDir, ext, logger, false)
+	_, err := v.Verify()
+	require.NoError(t, err)
+
+	// Re-run with sha256 — cache should miss entirely.
+	// But the library's filenames are built with md5 hashes, so sha256 verify will
+	// see inconsistencies (filename hash doesn't match). That's expected and
+	// orthogonal; what we check here is that no entries survive intersection.
+	ext.extractCalls.Store(0)
+	v2 := verifier.New(verifier.Config{
+		LibraryPath:   libDir,
+		SeparateVideo: false,
+		HashAlgo:      "sha256",
+		FailFast:      false,
+	}, ext, logger)
+	r, err := v2.Verify()
+	require.NoError(t, err)
+	assert.Equal(t, 0, r.CacheHits, "algo switch must invalidate all entries")
+	assert.Greater(t, ext.extractCalls.Load(), int64(0), "extractor runs for all files")
+}
+
+// TestVerifyCache_FixDoesNotWriteCache: files moved by --fix are NOT cached.
+// After the fix run, re-running without --fix should re-verify (extractor runs)
+// for the moved files.
+func TestVerifyCache_FixDoesNotWriteCache(t *testing.T) {
+	libDir := t.TempDir()
+	logger := logging.New(os.Stdout, os.Stderr, false)
+	ext := &fakeExtractor{}
+
+	// Place a file at a wrong path — the extractor's fake metadata will say it
+	// belongs under "Apple iPhone 15 Pro (image)/2024-08-20/" but we put it
+	// elsewhere.
+	wrongPath := filepath.Join(libDir, "2024", "sources", "WrongDev (image)", "2024-08-20", "placeholder.jpg")
+	require.NoError(t, os.MkdirAll(filepath.Dir(wrongPath), 0o755))
+	require.NoError(t, os.WriteFile(wrongPath, []byte("contents-to-fix"), 0o644))
+
+	// First run with Fix=true: moves the file, counts Fixed, should NOT add to cache.
+	v := verifier.New(verifier.Config{
+		LibraryPath:   libDir,
+		SeparateVideo: false,
+		HashAlgo:      "md5",
+		Fix:           true,
+		FailFast:      false,
+	}, ext, logger)
+	r1, err := v.Verify()
+	require.NoError(t, err)
+	assert.Equal(t, 1, r1.Fixed)
+	assert.Equal(t, 0, r1.CacheHits)
+
+	// Second run without Fix: file at new location should be re-verified from scratch
+	// (not a cache hit).
+	ext.extractCalls.Store(0)
+	v2 := verifier.New(verifier.Config{
+		LibraryPath:   libDir,
+		SeparateVideo: false,
+		HashAlgo:      "md5",
+		FailFast:      true,
+	}, ext, logger)
+	r2, err := v2.Verify()
+	require.NoError(t, err)
+	assert.Equal(t, 0, r2.CacheHits, "fixed file must not be in cache")
+	assert.Equal(t, int64(1), ext.extractCalls.Load(), "extractor should run for the re-verified file")
+}
+
+// TestVerifyCache_YearFilterIsolation: --year N only touches year N's cache;
+// other years' cache files are untouched.
+func TestVerifyCache_YearFilterIsolation(t *testing.T) {
+	// Build a library with 2 years by importing two separate sets with date-forced extractors.
+	libDir := t.TempDir()
+	logger := logging.New(os.Stdout, os.Stderr, false)
+
+	// Create synthetic source files for two years by manually placing them at
+	// their final library locations.
+	setupYear := func(year int, content string) {
+		t.Helper()
+		ext := &fakeExtractor{}
+		yd := time.Date(year, 8, 20, 18, 45, 3, 0, time.UTC)
+		// Import one file with a fake extractor that returns year=yd.
+		srcDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "p.jpg"), []byte(content), 0o644))
+		imp := importer.New(importer.Config{
+			LibraryPath:   libDir,
+			SeparateVideo: false,
+			HashAlgo:      "md5",
+			FailFast:      true,
+		}, &dateForcedExtractor{dt: yd, inner: ext}, logger)
+		_, err := imp.ImportDir(srcDir)
+		require.NoError(t, err)
+	}
+	setupYear(2023, "content-2023")
+	setupYear(2024, "content-2024")
+
+	ext := &dateForcedExtractor{dt: time.Date(2024, 8, 20, 18, 45, 3, 0, time.UTC), inner: &fakeExtractor{}}
+
+	// First: populate both years' caches.
+	v := verifier.New(verifier.Config{
+		LibraryPath:   libDir,
+		SeparateVideo: false,
+		HashAlgo:      "md5",
+		FailFast:      false,
+	}, ext, logger)
+	_, err := v.Verify()
+	require.NoError(t, err)
+
+	cache2023 := verifier.CacheFilePath(filepath.Join(libDir, "2023"))
+	cache2024 := verifier.CacheFilePath(filepath.Join(libDir, "2024"))
+	info2023Before, err := os.Stat(cache2023)
+	require.NoError(t, err)
+
+	// Second: only verify 2024 — 2023 cache must be untouched.
+	time.Sleep(10 * time.Millisecond) // ensure mtime granularity
+	v2 := verifier.New(verifier.Config{
+		LibraryPath:   libDir,
+		SeparateVideo: false,
+		HashAlgo:      "md5",
+		YearFilter:    "2024",
+		FailFast:      false,
+	}, ext, logger)
+	_, err = v2.Verify()
+	require.NoError(t, err)
+
+	info2023After, err := os.Stat(cache2023)
+	require.NoError(t, err)
+	assert.Equal(t, info2023Before.ModTime(), info2023After.ModTime(),
+		"2023 cache should not be touched when --year 2024 is used")
+
+	info2024, err := os.Stat(cache2024)
+	require.NoError(t, err)
+	assert.NotZero(t, info2024.Size())
+}
+
+// TestVerifyCache_ImvDirDoesNotFlagAsInconsistent: the .imv/ directory
+// created by the cache must not cause "unexpected directory" warnings.
+func TestVerifyCache_ImvDirDoesNotFlagAsInconsistent(t *testing.T) {
+	libDir, ext, logger := setupCachedLib(t)
+
+	// First verify creates .imv/ and populates the cache.
+	v := newVerifier(libDir, ext, logger, false)
+	r, err := v.Verify()
+	require.NoError(t, err)
+	assert.Equal(t, 0, r.Inconsistent, ".imv/ should be allowed at year level")
+
+	// Confirm the dir actually exists.
+	_, err = os.Stat(verifier.CacheDirPath(filepath.Join(libDir, "2024")))
+	require.NoError(t, err)
+}
+
+// TestVerifyCache_StrayCacheFileIgnored: a file with .cache extension placed
+// at a year level should be ignored (not flagged as unexpected).
+func TestVerifyCache_StrayCacheFileIgnored(t *testing.T) {
+	libDir, ext, logger := setupCachedLib(t)
+
+	require.NoError(t, os.WriteFile(filepath.Join(libDir, "2024", "stray.cache"), []byte("x"), 0o644))
+
+	v := verifier.New(verifier.Config{
+		LibraryPath:   libDir,
+		SeparateVideo: false,
+		HashAlgo:      "md5",
+		FailFast:      false,
+	}, ext, logger)
+	r, err := v.Verify()
+	require.NoError(t, err)
+	assert.Equal(t, 0, r.Inconsistent, "*.cache files should be ignored")
+}
+
+// dateForcedExtractor wraps another extractor and overrides DateTime.
+// Used to build synthetic multi-year libraries.
+type dateForcedExtractor struct {
+	dt    time.Time
+	inner *fakeExtractor
+}
+
+func (d *dateForcedExtractor) Extract(path string, hasher *defaults.Hasher) (*metadata.FileMetadata, error) {
+	md, err := d.inner.Extract(path, hasher)
+	if err != nil {
+		return nil, err
+	}
+	md.DateTime = d.dt
+	return md, nil
 }

--- a/internal/verifier/cache.go
+++ b/internal/verifier/cache.go
@@ -1,0 +1,310 @@
+package verifier
+
+import (
+	"bufio"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/askolesov/image-vault/internal/defaults"
+)
+
+const (
+	cacheFileName      = "verify.cache"
+	cacheDirName       = ".imv"
+	cacheFormatVersion = "v1"
+	cacheFieldSep      = "\t"
+	cacheFlushInterval = 10 * time.Second
+)
+
+// Entry is a single cached verification record.
+type Entry struct {
+	RelPath    string
+	Size       int64
+	MtimeNs    int64
+	HashAlgo   string
+	VerifiedAt int64
+}
+
+// Cache holds per-year verification cache state.
+// A nil *Cache is a valid no-op receiver for every method.
+type Cache struct {
+	path      string
+	entries   map[string]Entry
+	file      *os.File
+	buf       *bufio.Writer
+	lastFlush time.Time
+}
+
+// isSkippableInLibrary reports whether a filename should be silently skipped
+// during structural validation — OS junk files plus any .cache file (state
+// reserved for imv, not user content).
+func isSkippableInLibrary(name string) bool {
+	if defaults.IsIgnoredFile(name) {
+		return true
+	}
+	return strings.EqualFold(filepath.Ext(name), ".cache")
+}
+
+// CacheFilePath returns the canonical cache file path for a year directory.
+func CacheFilePath(yearDir string) string {
+	return filepath.Join(yearDir, cacheDirName, cacheFileName)
+}
+
+// CacheDirPath returns the .imv directory path for a year directory.
+func CacheDirPath(yearDir string) string {
+	return filepath.Join(yearDir, cacheDirName)
+}
+
+// NewEntry builds an Entry from a relative path, file info, and hash algo.
+// VerifiedAt is set to now.
+func NewEntry(relPath string, fi os.FileInfo, algo string) Entry {
+	return Entry{
+		RelPath:    relPath,
+		Size:       fi.Size(),
+		MtimeNs:    fi.ModTime().UnixNano(),
+		HashAlgo:   algo,
+		VerifiedAt: time.Now().Unix(),
+	}
+}
+
+// Load parses the cache file at path (if present) and returns a populated Cache.
+// A missing file is not an error. Malformed lines are silently skipped.
+// The returned Cache is not yet open for append — call Compact first.
+func Load(path string) (*Cache, error) {
+	c := &Cache{
+		path:    path,
+		entries: make(map[string]Entry),
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return c, nil
+		}
+		return nil, fmt.Errorf("open cache: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		e, ok := parseCacheLine(line)
+		if !ok {
+			continue
+		}
+		c.entries[e.RelPath] = e
+	}
+	if err := scanner.Err(); err != nil {
+		return c, fmt.Errorf("scan cache: %w", err)
+	}
+
+	return c, nil
+}
+
+// Lookup returns the cached entry for relPath, if any.
+func (c *Cache) Lookup(relPath string) (Entry, bool) {
+	if c == nil {
+		return Entry{}, false
+	}
+	e, ok := c.entries[relPath]
+	return e, ok
+}
+
+// Matches reports whether e is still valid for the given FileInfo and algo.
+func (c *Cache) Matches(e Entry, fi os.FileInfo, algo string) bool {
+	if c == nil || fi == nil {
+		return false
+	}
+	return e.Size == fi.Size() &&
+		e.MtimeNs == fi.ModTime().UnixNano() &&
+		e.HashAlgo == algo
+}
+
+// Entries returns a snapshot of current entries (read-only; for observability).
+func (c *Cache) Entries() map[string]Entry {
+	if c == nil {
+		return nil
+	}
+	out := make(map[string]Entry, len(c.entries))
+	maps.Copy(out, c.entries)
+	return out
+}
+
+// Compact rewrites the cache file to contain only the given keep entries,
+// then opens it for append. Uses tmp + fsync + rename for atomicity.
+// Leaves the original file untouched on any failure.
+func (c *Cache) Compact(keep map[string]Entry) error {
+	if c == nil {
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o755); err != nil {
+		return fmt.Errorf("mkdir cache dir: %w", err)
+	}
+
+	tmpPath := c.path + ".tmp"
+	tmp, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("create tmp cache: %w", err)
+	}
+
+	writer := bufio.NewWriter(tmp)
+	if err := writeCacheHeader(writer); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write cache header: %w", err)
+	}
+	for _, e := range keep {
+		if _, err := fmt.Fprintln(writer, formatCacheLine(e)); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmpPath)
+			return fmt.Errorf("write cache entry: %w", err)
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("flush tmp cache: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("fsync tmp cache: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close tmp cache: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, c.path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename cache: %w", err)
+	}
+
+	c.entries = make(map[string]Entry, len(keep))
+	maps.Copy(c.entries, keep)
+
+	f, err := os.OpenFile(c.path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("reopen cache for append: %w", err)
+	}
+	c.file = f
+	c.buf = bufio.NewWriter(f)
+	c.lastFlush = time.Now()
+
+	return nil
+}
+
+// AppendVerified records a verified file. Paths containing tab or newline
+// are rejected (they would corrupt the TSV format). Flush + fsync if the
+// time since last flush exceeds cacheFlushInterval.
+func (c *Cache) AppendVerified(e Entry) error {
+	if c == nil || c.file == nil || c.buf == nil {
+		return nil
+	}
+	if strings.ContainsAny(e.RelPath, "\t\n") {
+		return fmt.Errorf("cache: path contains tab or newline: %q", e.RelPath)
+	}
+	if _, err := fmt.Fprintln(c.buf, formatCacheLine(e)); err != nil {
+		return fmt.Errorf("append cache line: %w", err)
+	}
+	c.entries[e.RelPath] = e
+
+	if time.Since(c.lastFlush) > cacheFlushInterval {
+		return c.Flush()
+	}
+	return nil
+}
+
+// Flush empties the buffer and fsyncs.
+func (c *Cache) Flush() error {
+	if c == nil || c.file == nil || c.buf == nil {
+		return nil
+	}
+	if err := c.buf.Flush(); err != nil {
+		return fmt.Errorf("flush cache buffer: %w", err)
+	}
+	if err := c.file.Sync(); err != nil {
+		return fmt.Errorf("fsync cache: %w", err)
+	}
+	c.lastFlush = time.Now()
+	return nil
+}
+
+// Close flushes and closes the cache file. Idempotent.
+func (c *Cache) Close() error {
+	if c == nil || c.file == nil {
+		return nil
+	}
+	flushErr := c.Flush()
+	closeErr := c.file.Close()
+	c.file = nil
+	c.buf = nil
+	if flushErr != nil {
+		return flushErr
+	}
+	return closeErr
+}
+
+func writeCacheHeader(w *bufio.Writer) error {
+	if _, err := fmt.Fprintf(w, "# imv verify-cache %s \u2014 fields: path\\tsize\\tmtime_ns\\thash_algo\\tverified_at_unix\n", cacheFormatVersion); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# Invalidated when files are copied without preserving mtime. Use rsync -a or cp -p."); err != nil {
+		return err
+	}
+	return nil
+}
+
+func formatCacheLine(e Entry) string {
+	var b strings.Builder
+	b.WriteString(e.RelPath)
+	b.WriteString(cacheFieldSep)
+	b.WriteString(strconv.FormatInt(e.Size, 10))
+	b.WriteString(cacheFieldSep)
+	b.WriteString(strconv.FormatInt(e.MtimeNs, 10))
+	b.WriteString(cacheFieldSep)
+	b.WriteString(e.HashAlgo)
+	b.WriteString(cacheFieldSep)
+	b.WriteString(strconv.FormatInt(e.VerifiedAt, 10))
+	return b.String()
+}
+
+func parseCacheLine(line string) (Entry, bool) {
+	parts := strings.Split(line, cacheFieldSep)
+	if len(parts) != 5 {
+		return Entry{}, false
+	}
+	if parts[0] == "" || parts[3] == "" {
+		return Entry{}, false
+	}
+	size, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil || size < 0 {
+		return Entry{}, false
+	}
+	mtimeNs, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		return Entry{}, false
+	}
+	verifiedAt, err := strconv.ParseInt(parts[4], 10, 64)
+	if err != nil {
+		return Entry{}, false
+	}
+	return Entry{
+		RelPath:    parts[0],
+		Size:       size,
+		MtimeNs:    mtimeNs,
+		HashAlgo:   parts[3],
+		VerifiedAt: verifiedAt,
+	}, true
+}

--- a/internal/verifier/cache_test.go
+++ b/internal/verifier/cache_test.go
@@ -1,0 +1,348 @@
+package verifier
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeCacheFile writes raw contents to a cache file path for test setup.
+func writeCacheFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func TestCacheLoad_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	c, err := Load(filepath.Join(dir, "does-not-exist"))
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	assert.Empty(t, c.Entries())
+}
+
+func TestCacheLoad_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache")
+	writeCacheFile(t, path, "")
+	c, err := Load(path)
+	require.NoError(t, err)
+	assert.Empty(t, c.Entries())
+}
+
+func TestCacheLoad_HeaderOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache")
+	writeCacheFile(t, path, "# header\n# another\n")
+	c, err := Load(path)
+	require.NoError(t, err)
+	assert.Empty(t, c.Entries())
+}
+
+func TestCacheLoad_ValidRecords(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache")
+	content := "# header\n" +
+		"sources/Dev (image)/2024-01-15/a.jpg\t100\t1700000000000000000\tmd5\t1700000100\n" +
+		"sources/Dev (image)/2024-01-15/b.jpg\t200\t1700000000000000001\tsha256\t1700000200\n"
+	writeCacheFile(t, path, content)
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	assert.Len(t, c.Entries(), 2)
+
+	a, ok := c.Lookup("sources/Dev (image)/2024-01-15/a.jpg")
+	require.True(t, ok)
+	assert.Equal(t, int64(100), a.Size)
+	assert.Equal(t, int64(1700000000000000000), a.MtimeNs)
+	assert.Equal(t, "md5", a.HashAlgo)
+	assert.Equal(t, int64(1700000100), a.VerifiedAt)
+
+	b, ok := c.Lookup("sources/Dev (image)/2024-01-15/b.jpg")
+	require.True(t, ok)
+	assert.Equal(t, "sha256", b.HashAlgo)
+}
+
+func TestCacheLoad_DuplicatePathsLastWins(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache")
+	content := "p\t100\t1\tmd5\t10\n" +
+		"p\t200\t2\tsha256\t20\n"
+	writeCacheFile(t, path, content)
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	assert.Len(t, c.Entries(), 1)
+
+	e, ok := c.Lookup("p")
+	require.True(t, ok)
+	assert.Equal(t, int64(200), e.Size)
+	assert.Equal(t, "sha256", e.HashAlgo)
+}
+
+func TestCacheLoad_MalformedLinesSkipped(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache")
+	content := "# header\n" +
+		"too-few-fields\t100\tmd5\n" + // 3 fields, not 5
+		"\t100\t1\tmd5\t10\n" + // empty path
+		"p\tnot-a-number\t1\tmd5\t10\n" + // bad size
+		"p\t100\tnot-a-number\tmd5\t10\n" + // bad mtime
+		"p\t100\t1\tmd5\tnot-a-number\n" + // bad verified_at
+		"p\t-1\t1\tmd5\t10\n" + // negative size
+		"p\t100\t1\t\t10\n" + // empty algo
+		"valid\t100\t1\tmd5\t10\n"
+	writeCacheFile(t, path, content)
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	assert.Len(t, c.Entries(), 1)
+	_, ok := c.Lookup("valid")
+	assert.True(t, ok)
+}
+
+func TestCacheLoad_EmbeddedNewlineSplitsLine(t *testing.T) {
+	// A \n inside a path splits the record across two lines.
+	// The first fragment is malformed and dropped. The second fragment
+	// happens to look like a valid record with path="part2". This is
+	// benign: "part2" won't exist on disk, so compaction drops it.
+	// Write-side protection against this lives in AppendVerified.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache")
+	content := "part1\npart2\t100\t1\tmd5\t10\n"
+	writeCacheFile(t, path, content)
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	// The fragment "part1" is malformed (only 1 field) and gets dropped.
+	// "part2\t100\t1\tmd5\t10" parses as a valid record — nonsense path, but harmless.
+	_, ok := c.Lookup("part1")
+	assert.False(t, ok, "malformed first fragment should be dropped")
+}
+
+func TestCacheMatches(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "file")
+	require.NoError(t, os.WriteFile(filePath, []byte("hello"), 0o644))
+	fi, err := os.Stat(filePath)
+	require.NoError(t, err)
+
+	e := Entry{
+		Size:     fi.Size(),
+		MtimeNs:  fi.ModTime().UnixNano(),
+		HashAlgo: "md5",
+	}
+	c := &Cache{}
+
+	assert.True(t, c.Matches(e, fi, "md5"))
+	assert.False(t, c.Matches(e, fi, "sha256"), "algo differs")
+
+	eWrongSize := e
+	eWrongSize.Size = e.Size + 1
+	assert.False(t, c.Matches(eWrongSize, fi, "md5"))
+
+	eWrongMtime := e
+	eWrongMtime.MtimeNs = e.MtimeNs + 1
+	assert.False(t, c.Matches(eWrongMtime, fi, "md5"))
+}
+
+func TestCacheCompact_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".imv", "verify.cache")
+	// Pre-existing content that should be replaced entirely.
+	writeCacheFile(t, path,
+		"old\t1\t1\tmd5\t1\n"+
+			"kept\t100\t500\tmd5\t999\n")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+
+	keep := map[string]Entry{
+		"kept": {RelPath: "kept", Size: 100, MtimeNs: 500, HashAlgo: "md5", VerifiedAt: 999},
+	}
+	require.NoError(t, c.Compact(keep))
+	require.NoError(t, c.Close())
+
+	// Reload and check content.
+	c2, err := Load(path)
+	require.NoError(t, err)
+	assert.Len(t, c2.Entries(), 1)
+	e, ok := c2.Lookup("kept")
+	require.True(t, ok)
+	assert.Equal(t, int64(100), e.Size)
+
+	// Ensure old entry is gone.
+	_, ok = c2.Lookup("old")
+	assert.False(t, ok)
+}
+
+func TestCacheCompact_EmptyKeep(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".imv", "verify.cache")
+	writeCacheFile(t, path, "old\t1\t1\tmd5\t1\n")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	require.NoError(t, c.Compact(map[string]Entry{}))
+	require.NoError(t, c.Close())
+
+	c2, err := Load(path)
+	require.NoError(t, err)
+	assert.Empty(t, c2.Entries())
+}
+
+func TestCacheCompact_CreatesDirIfMissing(t *testing.T) {
+	dir := t.TempDir()
+	// Deep nested cache path where .imv/ doesn't exist yet.
+	path := filepath.Join(dir, "2024", ".imv", "verify.cache")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	require.NoError(t, c.Compact(map[string]Entry{
+		"file": {RelPath: "file", Size: 10, MtimeNs: 5, HashAlgo: "md5", VerifiedAt: 1},
+	}))
+	require.NoError(t, c.Close())
+
+	_, err = os.Stat(path)
+	assert.NoError(t, err)
+}
+
+func TestCacheAppendVerified_PersistsAfterFlush(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".imv", "verify.cache")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	require.NoError(t, c.Compact(map[string]Entry{}))
+
+	e := Entry{RelPath: "new", Size: 42, MtimeNs: 7, HashAlgo: "md5", VerifiedAt: 100}
+	require.NoError(t, c.AppendVerified(e))
+	require.NoError(t, c.Flush())
+
+	c2, err := Load(path)
+	require.NoError(t, err)
+	got, ok := c2.Lookup("new")
+	require.True(t, ok)
+	assert.Equal(t, int64(42), got.Size)
+}
+
+func TestCacheAppendVerified_PersistsAfterClose(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".imv", "verify.cache")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	require.NoError(t, c.Compact(map[string]Entry{}))
+	require.NoError(t, c.AppendVerified(Entry{RelPath: "x", Size: 1, MtimeNs: 1, HashAlgo: "md5", VerifiedAt: 1}))
+	require.NoError(t, c.Close())
+
+	c2, err := Load(path)
+	require.NoError(t, err)
+	_, ok := c2.Lookup("x")
+	assert.True(t, ok)
+}
+
+func TestCacheAppendVerified_RejectsTabInPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".imv", "verify.cache")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	require.NoError(t, c.Compact(map[string]Entry{}))
+
+	err = c.AppendVerified(Entry{RelPath: "has\ttab", Size: 1, MtimeNs: 1, HashAlgo: "md5", VerifiedAt: 1})
+	assert.Error(t, err)
+	require.NoError(t, c.Close())
+
+	// File should not contain a corrupted record.
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(content), "has\ttab")
+}
+
+func TestCacheAppendVerified_RejectsNewlineInPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".imv", "verify.cache")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	require.NoError(t, c.Compact(map[string]Entry{}))
+
+	err = c.AppendVerified(Entry{RelPath: "has\nnewline", Size: 1, MtimeNs: 1, HashAlgo: "md5", VerifiedAt: 1})
+	assert.Error(t, err)
+	require.NoError(t, c.Close())
+}
+
+func TestCacheClose_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".imv", "verify.cache")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	require.NoError(t, c.Compact(map[string]Entry{}))
+	require.NoError(t, c.Close())
+	require.NoError(t, c.Close(), "second Close should be no-op")
+}
+
+func TestCacheNilReceiver_AllMethodsNoOp(t *testing.T) {
+	var c *Cache
+
+	_, ok := c.Lookup("any")
+	assert.False(t, ok)
+	assert.False(t, c.Matches(Entry{}, nil, "md5"))
+	assert.Nil(t, c.Entries())
+	assert.NoError(t, c.Compact(nil))
+	assert.NoError(t, c.AppendVerified(Entry{}))
+	assert.NoError(t, c.Flush())
+	assert.NoError(t, c.Close())
+}
+
+func TestCacheLoad_CorruptGarbageReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache")
+	// Random binary garbage (no tab separators in expected positions).
+	writeCacheFile(t, path, "\x00\x01\x02\x03binary\x04garbage\x05nothing\x06valid\n")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	assert.Empty(t, c.Entries())
+}
+
+func TestCacheCompactWritesHeader(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".imv", "verify.cache")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	require.NoError(t, c.Compact(map[string]Entry{}))
+	require.NoError(t, c.Close())
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(content), "#"), "cache should start with a comment header")
+	assert.Contains(t, string(content), "verify-cache v1")
+}
+
+func TestCacheFilePath(t *testing.T) {
+	assert.Equal(t, filepath.Join("/lib/2024", ".imv", "verify.cache"), CacheFilePath("/lib/2024"))
+	assert.Equal(t, filepath.Join("/lib/2024", ".imv"), CacheDirPath("/lib/2024"))
+}
+
+func TestNewEntry(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f")
+	require.NoError(t, os.WriteFile(p, []byte("hi"), 0o644))
+	fi, err := os.Stat(p)
+	require.NoError(t, err)
+
+	e := NewEntry("rel", fi, "md5")
+	assert.Equal(t, "rel", e.RelPath)
+	assert.Equal(t, fi.Size(), e.Size)
+	assert.Equal(t, fi.ModTime().UnixNano(), e.MtimeNs)
+	assert.Equal(t, "md5", e.HashAlgo)
+	assert.Greater(t, e.VerifiedAt, int64(0))
+}

--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
+	"syscall"
 
 	"github.com/askolesov/image-vault/internal/defaults"
 	"github.com/askolesov/image-vault/internal/library"
@@ -30,6 +33,7 @@ type Config struct {
 	Fast          bool
 	Randomize     bool
 	YearFilter    string
+	NoCache       bool
 }
 
 // Result holds the outcome counts of a verify operation.
@@ -38,7 +42,15 @@ type Result struct {
 	Inconsistent   int
 	Fixed          int
 	Errors         int
+	CacheHits      int
 	ProcessedBytes int64
+}
+
+// FileEntry is one source file discovered during the per-year pre-walk.
+type FileEntry struct {
+	AbsPath   string
+	RelToYear string // forward-slash, used as cache key
+	Info      os.FileInfo
 }
 
 // Verifier orchestrates integrity checks on the library.
@@ -47,6 +59,9 @@ type Verifier struct {
 	ext    MetadataExtractor
 	logger *logging.Logger
 	hasher *defaults.Hasher
+
+	mu           sync.Mutex
+	currentCache *Cache
 }
 
 // New creates a new Verifier, initializing the hasher from cfg.HashAlgo
@@ -66,6 +81,26 @@ func New(cfg Config, ext MetadataExtractor, logger *logging.Logger) *Verifier {
 
 // Verify runs integrity checks on the library and returns the result.
 func (v *Verifier) Verify() (*Result, error) {
+	// Signal handler: on SIGINT/SIGTERM, flush+close the currently-open cache
+	// before letting the process exit. Ensures in-progress verified entries
+	// land on disk even on user-interrupt.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	doneCh := make(chan struct{})
+	defer func() {
+		signal.Stop(sigCh)
+		close(doneCh)
+	}()
+	go func() {
+		select {
+		case <-sigCh:
+			v.closeCurrentCache()
+			os.Exit(130)
+		case <-doneCh:
+			return
+		}
+	}()
+
 	years, err := library.ListYearsFiltered(v.cfg.LibraryPath, v.cfg.YearFilter)
 	if err != nil {
 		return nil, fmt.Errorf("list years: %w", err)
@@ -83,7 +118,7 @@ func (v *Verifier) Verify() (*Result, error) {
 	for i, year := range years {
 		yearDir := filepath.Join(v.cfg.LibraryPath, year)
 
-		// Validate year level — only sources/ and processed/ allowed
+		// Validate year level — only sources/, processed/, sources-manual/, .imv/ allowed
 		if err := v.verifyYearLevel(yearDir, year, result); err != nil {
 			return result, err
 		}
@@ -93,8 +128,20 @@ func (v *Verifier) Verify() (*Result, error) {
 			return result, err
 		}
 
-		// Validate individual source files
-		if err := v.verifySourceFiles(yearDir, year, i+1, len(years), result); err != nil {
+		// Pre-walk this year's source files and stat each once.
+		entries, err := v.walkAndStatYear(yearDir, year)
+		if err != nil {
+			return result, err
+		}
+
+		// Open the per-year cache (nil if disabled/fast/failed).
+		yc := v.openYearCache(yearDir, year, entries)
+		v.setCurrentCache(yc)
+
+		err = v.verifySourceFiles(year, entries, yc, i+1, len(years), result)
+		_ = yc.Close()
+		v.setCurrentCache(nil)
+		if err != nil {
 			return result, err
 		}
 	}
@@ -102,34 +149,105 @@ func (v *Verifier) Verify() (*Result, error) {
 	return result, nil
 }
 
-// verifySourceFiles checks each file in sources/ for correct path and hash.
-func (v *Verifier) verifySourceFiles(yearDir, year string, yearIdx, yearTotal int, result *Result) error {
-	files, err := library.ListSourceFiles(yearDir)
+// walkAndStatYear lists all source files under yearDir and stats each.
+// Paths that disappear between walk and stat are silently dropped.
+func (v *Verifier) walkAndStatYear(yearDir, year string) ([]FileEntry, error) {
+	paths, err := library.ListSourceFiles(yearDir)
 	if err != nil {
-		return fmt.Errorf("list source files for %s: %w", year, err)
+		return nil, fmt.Errorf("list source files for %s: %w", year, err)
+	}
+	entries := make([]FileEntry, 0, len(paths))
+	for _, p := range paths {
+		fi, err := os.Stat(p)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(yearDir, p)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, FileEntry{
+			AbsPath:   p,
+			RelToYear: filepath.ToSlash(rel),
+			Info:      fi,
+		})
+	}
+	return entries, nil
+}
+
+// openYearCache loads the year's cache file, builds the intersection with
+// currently-on-disk files, and atomically compacts to just the valid entries.
+// Returns nil if caching is disabled or any step fails (non-fatal).
+func (v *Verifier) openYearCache(yearDir, year string, entries []FileEntry) *Cache {
+	if v.cfg.NoCache || v.cfg.Fast {
+		return nil
 	}
 
+	cachePath := CacheFilePath(yearDir)
+	c, err := Load(cachePath)
+	if err != nil {
+		v.logger.Warn("cache for %s: load failed: %v (continuing without cache)", year, err)
+		return nil
+	}
+
+	keep := make(map[string]Entry)
+	for _, fe := range entries {
+		if existing, ok := c.Lookup(fe.RelToYear); ok {
+			if c.Matches(existing, fe.Info, v.cfg.HashAlgo) {
+				keep[fe.RelToYear] = existing
+			}
+		}
+	}
+
+	if err := c.Compact(keep); err != nil {
+		v.logger.Warn("cache for %s: compact failed: %v (continuing without cache)", year, err)
+		return nil
+	}
+	return c
+}
+
+func (v *Verifier) setCurrentCache(c *Cache) {
+	v.mu.Lock()
+	v.currentCache = c
+	v.mu.Unlock()
+}
+
+func (v *Verifier) closeCurrentCache() {
+	v.mu.Lock()
+	c := v.currentCache
+	v.mu.Unlock()
+	_ = c.Close()
+}
+
+// verifySourceFiles checks each file in sources/ for correct path and hash.
+// Consumes pre-walked entries; no internal walk or stat.
+func (v *Verifier) verifySourceFiles(
+	year string,
+	entries []FileEntry,
+	yc *Cache,
+	yearIdx, yearTotal int,
+	result *Result,
+) error {
 	if v.cfg.Randomize {
-		rand.Shuffle(len(files), func(i, j int) {
-			files[i], files[j] = files[j], files[i]
+		rand.Shuffle(len(entries), func(i, j int) {
+			entries[i], entries[j] = entries[j], entries[i]
 		})
 	}
 
-	total := len(files)
-	for i, filePath := range files {
+	total := len(entries)
+	for i, fe := range entries {
+		filePath := fe.AbsPath
 		prefix := fmt.Sprintf("[%s %d/%d] ", year, yearIdx, yearTotal)
-		stats := fmt.Sprintf("valid:%d fixed:%d inconsistent:%d %s",
-			result.Verified, result.Fixed, result.Inconsistent, logging.FormatBytes(result.ProcessedBytes))
+		stats := fmt.Sprintf("valid:%d cached:%d fixed:%d inconsistent:%d %s",
+			result.Verified, result.CacheHits, result.Fixed, result.Inconsistent, logging.FormatBytes(result.ProcessedBytes))
 		v.logger.ProgressWithStats(i+1, total, prefix, stats, filePath)
 
-		if info, err := os.Stat(filePath); err == nil {
-			result.ProcessedBytes += info.Size()
-		}
+		result.ProcessedBytes += fe.Info.Size()
 
 		baseName := filepath.Base(filePath)
 
 		// Skip ignored files
-		if defaults.IsIgnoredFile(baseName) {
+		if isSkippableInLibrary(baseName) {
 			continue
 		}
 
@@ -141,20 +259,11 @@ func (v *Verifier) verifySourceFiles(yearDir, year string, yearIdx, yearTotal in
 
 		// Structural consistency: filename date must match date dir,
 		// date dir year must match year level
-		sourcesDir := filepath.Join(yearDir, "sources")
-		relToSources, err := filepath.Rel(sourcesDir, filePath)
-		if err != nil {
-			result.Errors++
-			v.logger.Error("resolve relative path %s: %v", filePath, err)
-			continue
-		}
-
-		// relToSources is like: "Device (image)/2024-08-20/2024-08-20_18-45-03_abc123.jpg"
-		parts := strings.Split(filepath.ToSlash(relToSources), "/")
-		if len(parts) >= 3 {
+		parts := strings.Split(fe.RelToYear, "/")
+		// fe.RelToYear is like: "sources/Device (image)/2024-08-20/<file>"
+		if len(parts) >= 4 && parts[0] == "sources" {
 			dateDir := parts[len(parts)-2]
 
-			// Date dir year must match year level
 			if len(dateDir) >= 4 && dateDir[:4] != year {
 				result.Inconsistent++
 				v.logger.Warn("date dir %s has wrong year (expected %s): %s", dateDir, year, filePath)
@@ -164,7 +273,6 @@ func (v *Verifier) verifySourceFiles(yearDir, year string, yearIdx, yearTotal in
 				continue
 			}
 
-			// Filename date must match date dir
 			parsed, parseErr := pathbuilder.ParseSourceFilename(baseName)
 			if parseErr == nil {
 				fileDate := parsed.DateTime.Format("2006-01-02")
@@ -192,6 +300,15 @@ func (v *Verifier) verifySourceFiles(yearDir, year string, yearIdx, yearTotal in
 				result.Verified++
 			}
 			continue
+		}
+
+		// Cache hit: skip expensive ext.Extract + path rebuild.
+		if yc != nil {
+			if entry, ok := yc.Lookup(fe.RelToYear); ok && yc.Matches(entry, fe.Info, v.cfg.HashAlgo) {
+				result.Verified++
+				result.CacheHits++
+				continue
+			}
 		}
 
 		// Full mode: extract metadata, verify path and hash
@@ -228,6 +345,9 @@ func (v *Verifier) verifySourceFiles(yearDir, year string, yearIdx, yearTotal in
 			// Path matches — hash is correct by definition since the expected
 			// path is built from the content hash
 			result.Verified++
+			if err := yc.AppendVerified(NewEntry(fe.RelToYear, fe.Info, v.cfg.HashAlgo)); err != nil {
+				v.logger.Warn("cache append failed for %s: %v", filePath, err)
+			}
 		} else {
 			// Path mismatch (wrong dir, wrong hash in filename, etc.)
 			result.Inconsistent++
@@ -238,6 +358,7 @@ func (v *Verifier) verifySourceFiles(yearDir, year string, yearIdx, yearTotal in
 					v.logger.Error("fix move %s → %s: %v", filePath, expectedPath, err)
 				} else {
 					result.Fixed++
+					// Deliberately not caching fixed files — they'll re-verify next run.
 				}
 			}
 		}
@@ -254,7 +375,7 @@ func (v *Verifier) verifyLibraryRoot(result *Result) error {
 	}
 
 	for _, e := range entries {
-		if defaults.IsIgnoredFile(e.Name()) {
+		if isSkippableInLibrary(e.Name()) {
 			continue
 		}
 		if !e.IsDir() {
@@ -277,17 +398,23 @@ func (v *Verifier) verifyLibraryRoot(result *Result) error {
 	return nil
 }
 
-// verifyYearLevel checks that a year directory contains only sources/ and processed/.
+// verifyYearLevel checks that a year directory contains only sources/, processed/,
+// sources-manual/, and .imv/.
 func (v *Verifier) verifyYearLevel(yearDir, year string, result *Result) error {
 	entries, err := os.ReadDir(yearDir)
 	if err != nil {
 		return fmt.Errorf("read year dir %s: %w", year, err)
 	}
 
-	allowed := map[string]bool{"sources": true, "processed": true, "sources-manual": true}
+	allowed := map[string]bool{
+		"sources":        true,
+		"processed":      true,
+		"sources-manual": true,
+		cacheDirName:     true,
+	}
 
 	for _, e := range entries {
-		if defaults.IsIgnoredFile(e.Name()) {
+		if isSkippableInLibrary(e.Name()) {
 			continue
 		}
 		if !e.IsDir() {
@@ -323,7 +450,7 @@ func (v *Verifier) verifySourcesStructure(yearDir, year string, result *Result) 
 	}
 
 	for _, e := range entries {
-		if defaults.IsIgnoredFile(e.Name()) {
+		if isSkippableInLibrary(e.Name()) {
 			continue
 		}
 		if !e.IsDir() {
@@ -363,7 +490,7 @@ func (v *Verifier) verifyDeviceDir(deviceDir, year, deviceName string, result *R
 	}
 
 	for _, e := range entries {
-		if defaults.IsIgnoredFile(e.Name()) {
+		if isSkippableInLibrary(e.Name()) {
 			continue
 		}
 		if !e.IsDir() {
@@ -385,4 +512,3 @@ func (v *Verifier) verifyDeviceDir(deviceDir, year, deviceName string, result *R
 
 	return nil
 }
-


### PR DESCRIPTION
## Summary

Adds a persistent per-year verification cache so a crash-interrupted `imv verify` over a large library (tens of TB) can be resumed without re-reading every byte. Repeated verifies of an unchanged library now skip the expensive exiftool + full-file hash work for files whose size and mtime match the last successful verification.

## Design

Design spec committed in `docs/superpowers/specs/2026-04-19-verify-cache-design.md`.

- **Per-year** cache at `<year>/.imv/verify.cache`. The verifier already walks year-by-year, `--year` filter naturally scopes cache I/O, failure isolation is automatic, and rsync-ing a single year carries its cache along.
- **Append-only plain text**, tab-separated. Fields: `path` (relative to year), `size`, `mtime_ns`, `hash_algo`, `verified_at_unix`. Zero new dependencies, no binary-size bloat.
- **Atomic startup compaction:** at the top of each year, load the existing log, intersect with the current on-disk tree (size+mtime+algo match), write the keep set to `.tmp`, `fsync`, `rename` over the old log. Crash mid-compaction leaves the old log intact.
- **Fsync every 10 s** during append. Worst-case loss on hard crash: ~10 s of verified work.
- **SIGINT/SIGTERM handler** flushes the currently-open cache before the process exits.
- **`--fix` never writes to the cache** — only read-and-confirmed files go in. Fixed files re-verify on the next run.
- **`--fast` and `--no-cache`** bypass the cache entirely.
- **Invalidation rules:** size change, mtime change, hash-algo change, or file no longer at the same path. Copying a library with plain `cp -r` (no `-p`) will invalidate the cache; use `rsync -a` or `cp -p` to preserve mtime.

## Changes

- `internal/verifier/cache.go` — new file, ~300 lines. Nil-safe receivers throughout; any failure path degrades to a no-op cache rather than aborting verify.
- `internal/verifier/cache_test.go` — 20 unit tests: missing file, empty file, header-only, duplicates (last wins), malformed lines skipped, tab/newline rejection, compact atomicity, nil-receiver no-ops, binary-garbage recovery.
- `internal/integration_test.go` — 9 integration tests: cache hit skips extractor, mtime bump → miss, deleted file → compacted out, `--no-cache`, algo switch invalidates, `--fix` doesn't write cache, `--year` isolation, `.imv/` not flagged, stray `*.cache` files ignored structurally.
- `internal/verifier/verifier.go` — per-year pre-walk + stat (lifted from inside `verifySourceFiles`), `openYearCache` → intersection → compact at year top, signal handler, progress line adds `cached:N`.
- `internal/command/verify.go` — `--no-cache` flag, `Cache hits` row in summary.
- `README.md` — flag + mtime-preservation guidance.

## Test plan

- [x] `make test` — all 11 packages pass
- [x] `make lint` — 0 issues
- [x] `go build ./...` clean
- [ ] Manual: run `imv verify` over a real library, observe cache file created. Re-run, observe `cached:N` progress + near-zero wall time.
- [ ] Manual: `touch` one file, re-verify, confirm exactly one cache miss.
- [ ] Manual: Ctrl-C mid-verify, re-run, confirm previously-verified files are still cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)