### PR TITLE
fix(verify): always attempt remove+rename fallback on compact failure

### DIFF
--- a/internal/verifier/cache.go
+++ b/internal/verifier/cache.go
@@ -284,18 +284,23 @@ func (c *Cache) Close() error {
 }
 
 // renameOverwrite renames src to dst, falling back to remove + rename when
-// the filesystem refuses to overwrite an existing destination. POSIX
-// rename(2) overwrites, but some filesystems — notably SMB/CIFS shares and
-// several FUSE mounts — return EEXIST instead. The fallback is not atomic;
-// the brief window where dst is absent is acceptable for the cache, where
-// a missing file simply means "no hits" on the next reader.
+// the first rename fails. POSIX rename(2) overwrites, but SMB/CIFS shares
+// and several FUSE mounts refuse rename-over-existing with various errnos
+// (EEXIST, ENOTEMPTY, EACCES depending on the server) and wrapper layers
+// sometimes obscure the original errno. Rather than match specific errors,
+// we try the fallback on any rename failure — if the destination simply
+// doesn't exist we still fail with a meaningful error on the second rename.
+// The fallback is not atomic; the brief window where dst is absent is
+// acceptable for the cache, where a missing file simply means "no hits"
+// on the next reader.
 func renameOverwrite(src, dst string) error {
-	err := os.Rename(src, dst)
-	if err == nil || !errors.Is(err, fs.ErrExist) {
-		return err
+	if err := os.Rename(src, dst); err == nil {
+		return nil
 	}
-	if removeErr := os.Remove(dst); removeErr != nil {
-		return err
+	// Best-effort remove; ignore "not found" since that means rename failed
+	// for some other reason that removing dst won't help with.
+	if removeErr := os.Remove(dst); removeErr != nil && !errors.Is(removeErr, fs.ErrNotExist) {
+		return removeErr
 	}
 	return os.Rename(src, dst)
 }


### PR DESCRIPTION
## Summary
- PR #31's errors.Is(err, fs.ErrExist) gate misses cases where SMB/CIFS returns a different errno (EACCES, EPERM, or wrapped through the Apple SMB client) for the same "can't overwrite existing file" scenario. Reporter confirmed the previous fix did not resolve the issue on a mac↔ubuntu SMB setup.
- Drop the specific error check: on any rename failure, try remove + rename. If the destination genuinely doesn't exist, the second rename fails with a meaningful error. If removal itself fails for a non-ENOENT reason, surface that error instead of the original so the true cause is visible.

## Test plan
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `golangci-lint run`
- [x] Existing `TestCompact_OverwritesExistingCache` still passes.
- [ ] Manual: verify from a second machine against the SMB-mounted library — confirm "compact failed" warning is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)