### PR TITLE
refactor(verifier): stateless cache persist + remove IMV_DEBUG

### DIFF
--- a/docs/superpowers/plans/2026-04-19-verify-cache-stateless.md
+++ b/docs/superpowers/plans/2026-04-19-verify-cache-stateless.md
@@ -1,0 +1,947 @@
+# Verify Cache Stateless Persist Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the long-lived `O_APPEND` cache write handle with periodic wholesale snapshots (tmp + rename), and remove the `IMV_DEBUG` tracing helper added during the cross-FS firefight.
+
+**Architecture:** `internal/verifier/cache.go` is rewritten so the `Cache` type is purely an in-memory `map[string]Entry` plus a `Persist()` method that atomically rewrites the whole file. No file handle is held open between persists. Cadence: once per initial compaction, every 30s during the verify loop, and once at end-of-year. `internal/verifier/verifier.go` is adapted at three call sites (compact-after-load → `Persist`, `AppendVerified` → `Record`, `Close` → end-of-year `Persist`).
+
+**Tech Stack:** Go 1.23+, `testify/require` + `testify/assert`, stdlib only (no new deps). Existing `renameOverwrite` fallback and TSV file format are preserved unchanged.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-verify-cache-stateless-design.md`
+
+---
+
+## File Structure
+
+Files modified:
+
+- `internal/verifier/cache.go` — core rewrite. `Cache` struct loses `mu`, `file`, `buf`, `lastFlush`; gains `lastPersist`, `dirty`. `Compact` → `Persist`. `AppendVerified` → `Record`. `Flush`, `Close` removed. `debugLog` helper removed. `cacheFlushInterval` → `persistInterval`.
+- `internal/verifier/cache_test.go` — drop tests tied to the removed methods (append-after-compact, Flush cadence, Close idempotency, concurrent append/close); add tests for `Persist`, `Record`, and 30s cadence via direct manipulation of `lastPersist`.
+- `internal/verifier/verifier.go` — three call-site updates (`Compact` → `Persist`, `AppendVerified` → `Record`, `Close` → end-of-year `Persist`); stale comment on line 80 updated; 2 `debugLog` calls removed.
+
+Files not modified:
+
+- `internal/integration_test.go` — integration tests are black-box (file existence, counts, sizes). Current assertions remain valid for the new design.
+- `internal/command/verify.go` — no CLI surface change.
+- `README.md` — no user-facing change (`--no-cache` flag and cache file location unchanged).
+
+---
+
+## Task 1: Remove IMV_DEBUG tracing
+
+**Files:**
+- Modify: `internal/verifier/cache.go` (remove `debugLog` function at L324-L332; remove 14 call sites at L92, L95, L101, L121, L125, L172, L175, L182, L213, L216, L226, L232, L315, L318)
+- Modify: `internal/verifier/verifier.go` (remove 2 call sites at L183-L186, L191-L192)
+
+This task is a mechanical cleanup. It leaves `Cache` semantics identical; all existing tests must still pass unchanged.
+
+- [ ] **Step 1: Remove the `debugLog` function from `cache.go`**
+
+Delete these lines exactly (L323-L332 in the current file):
+
+```go
+// debugLog writes a diagnostic line to stderr when IMV_DEBUG is set. Used
+// to trace cache-path decisions without polluting normal output. The test
+// suite leaves IMV_DEBUG unset, so output is silent during CI.
+func debugLog(format string, args ...any) {
+	if os.Getenv("IMV_DEBUG") == "" {
+		return
+	}
+	_, _ = fmt.Fprintf(os.Stderr, "[imv-debug] "+format+"\n", args...)
+}
+```
+
+- [ ] **Step 2: Remove all `debugLog` call sites from `cache.go`**
+
+In `internal/verifier/cache.go`, delete every line matching `debugLog(...)`. There are 14:
+
+L92: `debugLog("load: %q missing; starting empty", path)` — inside `if os.IsNotExist(err)` branch of `Load`.
+L95: `debugLog("load: open %q failed: %v", path, err)` — inside the else of same branch.
+L100-L102: the `if fi, err := f.Stat(); err == nil { debugLog(...) }` block — delete the whole 3-line block.
+L121: `debugLog("load: scan error: %v", err)` — inside `if err := scanner.Err(); err != nil`.
+L125: `debugLog("load ok: %q entries=%d malformed=%d", path, len(c.entries), malformed)` — final debugLog in `Load`.
+L172: `debugLog("compact start: path=%q keep=%d", c.path, len(keep))` — top of `Compact`.
+L175: `debugLog("compact: mkdir failed: %v", err)` — inside `os.MkdirAll` error branch.
+L182: `debugLog("compact: open tmp %q failed: %v", tmpPath, err)` — inside tmp open error branch.
+L213: `debugLog("compact: tmp written ok at %q", tmpPath)` — after successful tmp close.
+L216: `debugLog("compact: renameOverwrite failed: %v", err)` — inside rename error branch.
+L226: `debugLog("compact: reopen for append failed: %v", err)` — inside reopen error branch.
+L232: `debugLog("compact ok: path=%q entries=%d", c.path, len(c.entries))` — final debugLog in `Compact`.
+L315: `debugLog("rename: %q -> %q ok", src, dst)` — success branch of `renameOverwrite`.
+L317: `debugLog("rename failed: %q -> %q: %v; retrying with remove", src, dst, err)` — error branch.
+
+Also simplify `renameOverwrite`'s if/else — once the two `debugLog` lines are gone, the `if err == nil { return nil } else { ... }` collapses to:
+
+```go
+func renameOverwrite(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+	_ = os.Remove(dst)
+	return os.Rename(src, dst)
+}
+```
+
+- [ ] **Step 3: Remove the 2 `debugLog` call sites from `verifier.go`**
+
+In `internal/verifier/verifier.go`, delete:
+
+L183-L187 (the match-miss debug block inside the `for _, fe := range entries` loop of `openYearCache`):
+
+```go
+			debugLog("openYearCache: %s match miss: cached=(size=%d mtime=%d algo=%s) disk=(size=%d mtime=%d algo=%s)",
+				fe.RelToYear,
+				existing.Size, existing.MtimeNs, existing.HashAlgo,
+				fe.Info.Size(), fe.Info.ModTime().UnixNano(), v.cfg.HashAlgo)
+```
+
+L191-L192 (the summary debug line after the loop):
+
+```go
+	debugLog("openYearCache[%s]: loaded=%d entries=%d keep=%d lookupMiss=%d matchMiss=%d",
+		year, loaded, len(entries), len(keep), lookupMiss, matchMiss)
+```
+
+After removing the second block, the local variables `loaded`, `matchMiss`, and `lookupMiss` are only incremented but never read. Delete their declarations and increments as well:
+
+- Remove `loaded := len(c.entries)` (was L172).
+- Remove `var matchMiss, lookupMiss int` (was L174).
+- Remove `lookupMiss++` (was L178) — keep the `continue` branch itself, just drop the counter increment.
+- Remove `matchMiss++` (was L182) — same treatment.
+
+- [ ] **Step 4: Confirm `os` is still imported in `cache.go`**
+
+`cache.go` uses `os` for file operations elsewhere. After removing `debugLog`, run:
+
+```bash
+go build ./internal/verifier/...
+```
+
+Expected: clean build, no "imported and not used" errors. If the build complains about anything in `cache.go`, something else in Step 1/2 was deleted incorrectly — reread and fix.
+
+- [ ] **Step 5: Run tests to confirm no regression**
+
+```bash
+go test ./internal/verifier/... -count=1
+```
+
+Expected: all existing tests pass. No new tests were added and no behavior changed; any failure means a non-tracing code path was removed by mistake.
+
+- [ ] **Step 6: Confirm IMV_DEBUG is completely gone**
+
+```bash
+grep -rn "IMV_DEBUG\|debugLog" internal/ cmd/
+```
+
+Expected: no output (the env var and helper are only referenced in the spec/plan docs now).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/verifier/cache.go internal/verifier/verifier.go
+git commit -m "$(cat <<'EOF'
+refactor(verifier): remove IMV_DEBUG tracing helper
+
+The debugLog helper and IMV_DEBUG env var were added during the
+cross-FS rename firefight to trace cache-path decisions. With the
+upcoming stateless-persist redesign the failure modes it traced go
+away, so remove it now. User-facing v.logger.Warn calls are kept.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Stateless cache redesign (TDD, single commit)
+
+**Files:**
+- Modify: `internal/verifier/cache_test.go` (drop obsolete tests, add new ones)
+- Modify: `internal/verifier/cache.go` (new `Cache` struct, `Persist`, `Record`; drop `Compact`, `AppendVerified`, `Flush`, `Close`)
+- Modify: `internal/verifier/verifier.go` (3 call-site updates + 1 stale comment)
+
+This task is one commit but multiple TDD steps. Between steps the tree will be red (compile errors and/or test failures). This is expected — the rewrite is too interdependent to split across commits.
+
+- [ ] **Step 1: Rewrite `internal/verifier/cache_test.go` to describe new semantics**
+
+Keep these existing tests unchanged — they test `Load`, `Matches`, `Lookup`, `NewEntry`, `CacheFilePath`, `renameOverwrite` which are unchanged by this refactor:
+
+- `TestCacheLoad_MissingFile`
+- `TestCacheLoad_EmptyFile`
+- `TestCacheLoad_HeaderOnly`
+- `TestCacheLoad_ValidRecords`
+- `TestCacheLoad_DuplicatePathsLastWins`
+- `TestCacheLoad_MalformedLinesSkipped`
+- `TestCacheLoad_EmbeddedNewlineSplitsLine`
+- `TestCacheLoad_CorruptGarbageReturnsEmpty`
+- `TestCacheMatches`
+- `TestCacheMatches_CrossHostSMBScenario`
+- `TestCacheFilePath`
+- `TestNewEntry`
+- `TestRenameOverwrite_FallbackWhenEEXIST`
+
+**Delete** these tests entirely — they test behavior of `Compact`/`AppendVerified`/`Flush`/`Close` that no longer exists:
+
+- `TestCacheCompact_HappyPath`
+- `TestCacheCompact_EmptyKeep`
+- `TestCacheCompact_CreatesDirIfMissing`
+- `TestCacheCompactWritesHeader`
+- `TestCompact_OverwritesExistingCache`
+- `TestCacheAppendVerified_PersistsAfterFlush`
+- `TestCacheAppendVerified_PersistsAfterClose`
+- `TestCacheAppendVerified_RejectsTabInPath`
+- `TestCacheAppendVerified_RejectsNewlineInPath`
+- `TestCacheClose_Idempotent`
+- `TestCacheConcurrentAppendAndClose` (no concurrency left — no mutex, no signal handler)
+
+**Replace** `TestCacheNilReceiver_AllMethodsNoOp` (L362-L373) with a version that uses the new method set:
+
+```go
+func TestCacheNilReceiver_AllMethodsNoOp(t *testing.T) {
+	var c *Cache
+
+	_, ok := c.Lookup("any")
+	assert.False(t, ok)
+	assert.False(t, c.Matches(Entry{}, nil, "md5"))
+	assert.Nil(t, c.Entries())
+	assert.NoError(t, c.Record(Entry{}))
+	assert.NoError(t, c.Persist())
+}
+```
+
+**Update** the comment block at L110-L115 inside `TestCacheLoad_EmbeddedNewlineSplitsLine` — change `AppendVerified` to `Record`:
+
+Old: `// Write-side protection against this lives in AppendVerified.`
+New: `// Write-side protection against this lives in Record.`
+
+**Add** these new tests at the end of the file (after `TestNewEntry`):
+
+```go
+// TestCachePersist_HappyPath: Persist writes the header and all in-memory
+// entries to disk, creating the parent .imv/ directory if needed.
+func TestCachePersist_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".imv", "verify.cache")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	c.entries["a.jpg"] = Entry{RelPath: "a.jpg", Size: 100, MtimeNs: 500, HashAlgo: "md5", VerifiedAt: 999}
+	c.dirty = true
+
+	require.NoError(t, c.Persist())
+
+	// Reload to confirm on-disk content.
+	c2, err := Load(path)
+	require.NoError(t, err)
+	assert.Len(t, c2.Entries(), 1)
+	got, ok := c2.Lookup("a.jpg")
+	require.True(t, ok)
+	assert.Equal(t, int64(100), got.Size)
+
+	// dirty flag cleared after a successful persist.
+	assert.False(t, c.dirty)
+}
+
+// TestCachePersist_OverwritesExistingFile: second Persist replaces first
+// cleanly — regression for the cross-machine "rename: file exists" case.
+func TestCachePersist_OverwritesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".imv", "verify.cache")
+
+	c1, err := Load(path)
+	require.NoError(t, err)
+	c1.entries["a.jpg"] = Entry{RelPath: "a.jpg", Size: 1, MtimeNs: 1, HashAlgo: "md5", VerifiedAt: 1}
+	c1.dirty = true
+	require.NoError(t, c1.Persist())
+
+	c2, err := Load(path)
+	require.NoError(t, err)
+	c2.entries = map[string]Entry{
+		"b.jpg": {RelPath: "b.jpg", Size: 2, MtimeNs: 2, HashAlgo: "md5", VerifiedAt: 2},
+	}
+	c2.dirty = true
+	require.NoError(t, c2.Persist())
+
+	c3, err := Load(path)
+	require.NoError(t, err)
+	_, hasA := c3.Lookup("a.jpg")
+	_, hasB := c3.Lookup("b.jpg")
+	assert.False(t, hasA, "old entry should have been overwritten")
+	assert.True(t, hasB, "new entry should be present")
+}
+
+// TestCachePersist_EmptyWritesHeader: persisting with no entries yields
+// a file with just the header comment — matches old Compact_EmptyKeep.
+func TestCachePersist_EmptyWritesHeader(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".imv", "verify.cache")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	require.NoError(t, c.Persist())
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(content), "#"), "should start with comment header")
+	assert.Contains(t, string(content), "verify-cache v1")
+}
+
+// TestCachePersist_CreatesDirIfMissing: .imv/ is created as needed.
+func TestCachePersist_CreatesDirIfMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "2024", ".imv", "verify.cache")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	c.entries["file"] = Entry{RelPath: "file", Size: 10, MtimeNs: 5, HashAlgo: "md5", VerifiedAt: 1}
+	c.dirty = true
+	require.NoError(t, c.Persist())
+
+	_, err = os.Stat(path)
+	assert.NoError(t, err)
+}
+
+// TestCacheRecord_InMemoryOnly: Record inserts into the map and flips
+// dirty, but does not write to disk when the persist interval has not
+// elapsed. Verify by checking the cache file does not exist yet.
+func TestCacheRecord_InMemoryOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".imv", "verify.cache")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	// Make Record think we persisted "just now" so its cadence check doesn't fire.
+	c.lastPersist = time.Now()
+
+	e := Entry{RelPath: "new", Size: 42, MtimeNs: 7, HashAlgo: "md5", VerifiedAt: 100}
+	require.NoError(t, c.Record(e))
+
+	assert.True(t, c.dirty)
+	got, ok := c.Lookup("new")
+	require.True(t, ok)
+	assert.Equal(t, int64(42), got.Size)
+
+	// No file should exist on disk yet.
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err), "Record must not write to disk when interval has not elapsed")
+}
+
+// TestCacheRecord_TriggersPersistAfterInterval: once persistInterval has
+// elapsed since lastPersist, Record triggers a Persist() as a side effect.
+func TestCacheRecord_TriggersPersistAfterInterval(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".imv", "verify.cache")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	// Pretend we last persisted an hour ago.
+	c.lastPersist = time.Now().Add(-1 * time.Hour)
+
+	e := Entry{RelPath: "new", Size: 1, MtimeNs: 1, HashAlgo: "md5", VerifiedAt: 1}
+	require.NoError(t, c.Record(e))
+
+	// File should exist and contain the entry.
+	c2, err := Load(path)
+	require.NoError(t, err)
+	_, ok := c2.Lookup("new")
+	assert.True(t, ok, "Record should have triggered Persist after interval elapsed")
+
+	// lastPersist should be updated (near now), dirty cleared.
+	assert.WithinDuration(t, time.Now(), c.lastPersist, 5*time.Second)
+	assert.False(t, c.dirty)
+}
+
+// TestCacheRecord_RejectsTabInPath: path containing \t is rejected
+// without mutating the map or writing to disk.
+func TestCacheRecord_RejectsTabInPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".imv", "verify.cache")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	c.lastPersist = time.Now().Add(-1 * time.Hour) // would otherwise persist
+
+	err = c.Record(Entry{RelPath: "has\ttab", Size: 1, MtimeNs: 1, HashAlgo: "md5", VerifiedAt: 1})
+	assert.Error(t, err)
+
+	_, ok := c.Lookup("has\ttab")
+	assert.False(t, ok, "map must not contain the rejected entry")
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err), "no persist should have happened")
+}
+
+// TestCacheRecord_RejectsNewlineInPath: same as above for \n.
+func TestCacheRecord_RejectsNewlineInPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".imv", "verify.cache")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+
+	err = c.Record(Entry{RelPath: "has\nnewline", Size: 1, MtimeNs: 1, HashAlgo: "md5", VerifiedAt: 1})
+	assert.Error(t, err)
+	_, ok := c.Lookup("has\nnewline")
+	assert.False(t, ok)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/verifier/... -count=1 -run 'TestCachePersist|TestCacheRecord|TestCacheNilReceiver' 2>&1 | head -40
+```
+
+Expected: compile failure with messages like `c.entries undefined`, `c.dirty undefined`, `c.lastPersist undefined`, `c.Record undefined`, `c.Persist undefined`. (The fields `entries`, `lastFlush`, `buf`, `file`, `mu` exist on the current `Cache` struct but `lastPersist` and `dirty` do not; `Record` and `Persist` methods do not exist.)
+
+This red state is expected — we're in the middle of TDD.
+
+- [ ] **Step 3: Rewrite `internal/verifier/cache.go`**
+
+Replace the entire file with the content below. Key changes summarized:
+- `Cache` struct: drop `mu`, `file`, `buf`, `lastFlush`; add `lastPersist`, `dirty`.
+- Drop `Compact`, `AppendVerified`, `Flush`, `Close`, `flushLocked` methods.
+- Add `Persist`, `Record` methods.
+- Drop `cacheFlushInterval` constant, add `persistInterval = 30 * time.Second` constant.
+- Drop the `sync` and `bufio` imports from the package declaration if they become unused (note: `bufio.NewScanner` is still used in `Load`, and `bufio.NewWriter` is still used inside `Persist` — both imports stay).
+
+Full file (L1-L end) — write this wholesale to `internal/verifier/cache.go`:
+
+```go
+package verifier
+
+import (
+	"bufio"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/askolesov/image-vault/internal/defaults"
+)
+
+const (
+	cacheFileName      = "verify.cache"
+	cacheDirName       = ".imv"
+	cacheFormatVersion = "v1"
+	cacheFieldSep      = "\t"
+	persistInterval    = 30 * time.Second
+)
+
+// Entry is a single cached verification record.
+type Entry struct {
+	RelPath    string
+	Size       int64
+	MtimeNs    int64
+	HashAlgo   string
+	VerifiedAt int64
+}
+
+// Cache holds per-year verification cache state. It is an in-memory
+// map[string]Entry plus a Persist method that atomically rewrites the
+// whole file. No file handle is held open between persists — this is
+// the key property that keeps the cache stable across cross-filesystem
+// scenarios (SMB/CIFS, FUSE, permission drift between machines).
+//
+// A nil *Cache is a valid no-op receiver for every method.
+type Cache struct {
+	path        string
+	entries     map[string]Entry
+	lastPersist time.Time
+	dirty       bool
+}
+
+// isSkippableInLibrary reports whether a filename should be silently skipped
+// during structural validation — OS junk files plus any .cache file (state
+// reserved for imv, not user content).
+func isSkippableInLibrary(name string) bool {
+	if defaults.IsIgnoredFile(name) {
+		return true
+	}
+	return strings.EqualFold(filepath.Ext(name), ".cache")
+}
+
+// CacheFilePath returns the canonical cache file path for a year directory.
+func CacheFilePath(yearDir string) string {
+	return filepath.Join(yearDir, cacheDirName, cacheFileName)
+}
+
+// CacheDirPath returns the .imv directory path for a year directory.
+func CacheDirPath(yearDir string) string {
+	return filepath.Join(yearDir, cacheDirName)
+}
+
+// NewEntry builds an Entry from a relative path, file info, and hash algo.
+// VerifiedAt is set to now.
+func NewEntry(relPath string, fi os.FileInfo, algo string) Entry {
+	return Entry{
+		RelPath:    relPath,
+		Size:       fi.Size(),
+		MtimeNs:    fi.ModTime().UnixNano(),
+		HashAlgo:   algo,
+		VerifiedAt: time.Now().Unix(),
+	}
+}
+
+// Load parses the cache file at path (if present) and returns a populated
+// Cache. A missing file is not an error. Malformed lines are silently
+// skipped. The returned Cache has lastPersist zero-valued (so the first
+// Record after Load will trigger a persist, or the caller can call Persist
+// directly after filtering entries).
+func Load(path string) (*Cache, error) {
+	c := &Cache{
+		path:    path,
+		entries: make(map[string]Entry),
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return c, nil
+		}
+		return nil, fmt.Errorf("open cache: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		e, ok := parseCacheLine(line)
+		if !ok {
+			continue
+		}
+		c.entries[e.RelPath] = e
+	}
+	if err := scanner.Err(); err != nil {
+		return c, fmt.Errorf("scan cache: %w", err)
+	}
+
+	return c, nil
+}
+
+// Lookup returns the cached entry for relPath, if any.
+func (c *Cache) Lookup(relPath string) (Entry, bool) {
+	if c == nil {
+		return Entry{}, false
+	}
+	e, ok := c.entries[relPath]
+	return e, ok
+}
+
+// Matches reports whether e is still valid for the given FileInfo and algo.
+// Mtime is compared at whole-second precision: SMB/CIFS, NFSv3, FAT, and
+// several FUSE mounts quantize mtime to seconds, so a cache populated on
+// one host (native FS, nanosecond precision) and read on another (SMB,
+// second precision) against the same underlying file would otherwise
+// mismatch every entry. Second granularity is the common denominator
+// supported by every filesystem we care about.
+func (c *Cache) Matches(e Entry, fi os.FileInfo, algo string) bool {
+	if c == nil || fi == nil {
+		return false
+	}
+	const nsPerSec = int64(time.Second)
+	return e.Size == fi.Size() &&
+		e.MtimeNs/nsPerSec == fi.ModTime().Unix() &&
+		e.HashAlgo == algo
+}
+
+// Entries returns a snapshot of current entries (read-only; for observability).
+func (c *Cache) Entries() map[string]Entry {
+	if c == nil {
+		return nil
+	}
+	out := make(map[string]Entry, len(c.entries))
+	maps.Copy(out, c.entries)
+	return out
+}
+
+// Persist atomically rewrites the on-disk cache file from the current
+// in-memory entries. Uses tmp + fsync + rename (with remove+rename
+// fallback for filesystems that refuse overwrite). On success: clears
+// dirty and updates lastPersist. On failure: leaves the original file
+// untouched and the in-memory map unchanged.
+func (c *Cache) Persist() error {
+	if c == nil {
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o755); err != nil {
+		return fmt.Errorf("mkdir cache dir: %w", err)
+	}
+
+	tmpPath := c.path + ".tmp"
+	tmp, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("create tmp cache: %w", err)
+	}
+
+	writer := bufio.NewWriter(tmp)
+	if err := writeCacheHeader(writer); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write cache header: %w", err)
+	}
+	for _, e := range c.entries {
+		if _, err := fmt.Fprintln(writer, formatCacheLine(e)); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmpPath)
+			return fmt.Errorf("write cache entry: %w", err)
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("flush tmp cache: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("fsync tmp cache: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close tmp cache: %w", err)
+	}
+
+	if err := renameOverwrite(tmpPath, c.path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename cache: %w", err)
+	}
+
+	c.lastPersist = time.Now()
+	c.dirty = false
+	return nil
+}
+
+// Record inserts e into the in-memory cache. If persistInterval has
+// elapsed since lastPersist and the cache is dirty, Record also calls
+// Persist as a side effect. Paths containing tab or newline are rejected
+// (they would corrupt the TSV format) — the map is not mutated and no
+// persist happens in that case.
+func (c *Cache) Record(e Entry) error {
+	if c == nil {
+		return nil
+	}
+	if strings.ContainsAny(e.RelPath, "\t\n") {
+		return fmt.Errorf("cache: path contains tab or newline: %q", e.RelPath)
+	}
+	c.entries[e.RelPath] = e
+	c.dirty = true
+
+	if time.Since(c.lastPersist) > persistInterval {
+		return c.Persist()
+	}
+	return nil
+}
+
+// renameOverwrite renames src over dst. POSIX rename(2) overwrites on the
+// same filesystem, but SMB/CIFS and several FUSE mounts refuse to overwrite
+// with various errnos. On any rename failure, remove dst and retry. If the
+// retry fails the cache is lost — acceptable since this is a regenerable
+// cache, not durable state.
+func renameOverwrite(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+	_ = os.Remove(dst)
+	return os.Rename(src, dst)
+}
+
+func writeCacheHeader(w *bufio.Writer) error {
+	if _, err := fmt.Fprintf(w, "# imv verify-cache %s \u2014 fields: path\\tsize\\tmtime_ns\\thash_algo\\tverified_at_unix\n", cacheFormatVersion); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# Invalidated when files are copied without preserving mtime. Use rsync -a or cp -p."); err != nil {
+		return err
+	}
+	return nil
+}
+
+func formatCacheLine(e Entry) string {
+	var b strings.Builder
+	b.WriteString(e.RelPath)
+	b.WriteString(cacheFieldSep)
+	b.WriteString(strconv.FormatInt(e.Size, 10))
+	b.WriteString(cacheFieldSep)
+	b.WriteString(strconv.FormatInt(e.MtimeNs, 10))
+	b.WriteString(cacheFieldSep)
+	b.WriteString(e.HashAlgo)
+	b.WriteString(cacheFieldSep)
+	b.WriteString(strconv.FormatInt(e.VerifiedAt, 10))
+	return b.String()
+}
+
+func parseCacheLine(line string) (Entry, bool) {
+	parts := strings.Split(line, cacheFieldSep)
+	if len(parts) != 5 {
+		return Entry{}, false
+	}
+	if parts[0] == "" || parts[3] == "" {
+		return Entry{}, false
+	}
+	size, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil || size < 0 {
+		return Entry{}, false
+	}
+	mtimeNs, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		return Entry{}, false
+	}
+	verifiedAt, err := strconv.ParseInt(parts[4], 10, 64)
+	if err != nil {
+		return Entry{}, false
+	}
+	return Entry{
+		RelPath:    parts[0],
+		Size:       size,
+		MtimeNs:    mtimeNs,
+		HashAlgo:   parts[3],
+		VerifiedAt: verifiedAt,
+	}, true
+}
+```
+
+- [ ] **Step 4: Update `internal/verifier/verifier.go` to use the new API**
+
+Three edits inside `verifier.go`:
+
+**Edit 1** — update the stale doc comment on the `Verify` method (L77-L83). Change:
+
+```go
+// Verify runs integrity checks on the library and returns the result.
+//
+// No signal handling: a SIGINT terminates the process via Go's default
+// handler. The cache is flushed every ~cacheFlushInterval during normal
+// operation, so a crash loses at most that window of AppendVerified
+// entries. Anything un-flushed is regenerated on the next run — this is
+// a verification cache, not durable state.
+```
+
+To:
+
+```go
+// Verify runs integrity checks on the library and returns the result.
+//
+// No signal handling: a SIGINT terminates the process via Go's default
+// handler. The cache is persisted every ~persistInterval during normal
+// operation plus once at end of year, so a crash loses at most that
+// window of recorded entries. Anything un-persisted is regenerated on
+// the next run — this is a verification cache, not durable state.
+```
+
+**Edit 2** — update the per-year body of `Verify` (the `for i, year := range years { ... }` loop around L99-L126). The existing body ends with:
+
+```go
+		yc := v.openYearCache(yearDir, year, entries)
+
+		err = v.verifySourceFiles(year, entries, yc, i+1, len(years), result)
+		_ = yc.Close()
+		if err != nil {
+			return result, err
+		}
+```
+
+Replace with:
+
+```go
+		yc := v.openYearCache(yearDir, year, entries)
+
+		err = v.verifySourceFiles(year, entries, yc, i+1, len(years), result)
+		// End-of-year persist: runs on success and error paths alike, matching
+		// the old Close() semantics. Best-effort; failure is logged but does
+		// not fail Verify. openYearCache already did the initial persist, so
+		// this one is a no-op if no new entries were recorded.
+		if yc != nil && yc.dirty {
+			if perr := yc.Persist(); perr != nil {
+				v.logger.Warn("cache for %s: end-of-year persist failed: %v", year, perr)
+			}
+		}
+		if err != nil {
+			return result, err
+		}
+```
+
+**Edit 3** — update `openYearCache` to call `Persist` in place of `Compact`. Current body (L160-L199 after debug-log removal in Task 1 — the surrounding shape is):
+
+```go
+func (v *Verifier) openYearCache(yearDir, year string, entries []FileEntry) *Cache {
+	if v.cfg.NoCache || v.cfg.Fast {
+		return nil
+	}
+
+	cachePath := CacheFilePath(yearDir)
+	c, err := Load(cachePath)
+	if err != nil {
+		v.logger.Warn("cache for %s: load failed: %v (continuing without cache)", year, err)
+		return nil
+	}
+
+	keep := make(map[string]Entry)
+	for _, fe := range entries {
+		existing, ok := c.Lookup(fe.RelToYear)
+		if !ok {
+			continue
+		}
+		if !c.Matches(existing, fe.Info, v.cfg.HashAlgo) {
+			continue
+		}
+		keep[fe.RelToYear] = existing
+	}
+
+	if err := c.Compact(keep); err != nil {
+		v.logger.Warn("cache for %s: compact failed: %v (continuing without cache)", year, err)
+		return nil
+	}
+	return c
+}
+```
+
+Replace the final `if err := c.Compact(keep); ...` block (last 5 lines above the closing brace) with:
+
+```go
+	c.entries = keep
+	c.dirty = true
+	if err := c.Persist(); err != nil {
+		v.logger.Warn("cache for %s: initial persist failed: %v (continuing without cache)", year, err)
+		return nil
+	}
+	return c
+```
+
+**Edit 4** — update the `AppendVerified` call site inside `verifySourceFiles` (around L330). The current code is:
+
+```go
+		if absActual == absExpected {
+			// Path matches — hash is correct by definition since the expected
+			// path is built from the content hash
+			result.Verified++
+			if err := yc.AppendVerified(NewEntry(fe.RelToYear, fe.Info, v.cfg.HashAlgo)); err != nil {
+				v.logger.Warn("cache append failed for %s: %v", filePath, err)
+			}
+		} else {
+```
+
+Change `yc.AppendVerified(...)` to `yc.Record(...)` and update the warning message:
+
+```go
+		if absActual == absExpected {
+			// Path matches — hash is correct by definition since the expected
+			// path is built from the content hash
+			result.Verified++
+			if err := yc.Record(NewEntry(fe.RelToYear, fe.Info, v.cfg.HashAlgo)); err != nil {
+				v.logger.Warn("cache record failed for %s: %v", filePath, err)
+			}
+		} else {
+```
+
+- [ ] **Step 5: Run the full verifier test suite to verify everything passes**
+
+```bash
+go test ./internal/verifier/... -count=1 -race
+```
+
+Expected: all tests pass, including the newly-added `TestCachePersist_*` and `TestCacheRecord_*` tests, the unchanged `TestCacheLoad_*` / `TestCacheMatches_*` tests, and the renamed `TestCacheNilReceiver_AllMethodsNoOp`. `-race` should be clean since the mutex is gone and no new concurrency was introduced.
+
+If compile errors appear mentioning `AppendVerified`, `Compact`, `Close`, `Flush`, `cacheFlushInterval`, or `debugLog` — something from the rewrite wasn't applied. Re-read Steps 3 and 4.
+
+- [ ] **Step 6: Run integration tests**
+
+```bash
+go test ./internal/... -count=1 -race
+```
+
+Expected: all integration tests pass, including `TestVerifyCache_SecondRunSkipsExtract`, `TestVerifyCache_MtimeMismatchCausesMiss`, `TestVerifyCache_DeletedFileCompactedOut`, `TestVerifyCache_NoCacheFlag`, and any sibling tests in `internal/integration_test.go`. These are black-box and should not care about the internal handle rewrite.
+
+- [ ] **Step 7: Run the full test suite**
+
+```bash
+go test ./... -count=1 -race
+```
+
+Expected: everything passes. No other package imports the cache subsystem today, but run the full suite for safety.
+
+- [ ] **Step 8: Build the binary and run `go vet`**
+
+```bash
+go build ./cmd/imv && go vet ./...
+```
+
+Expected: clean build of `imv` binary in the working tree; zero `go vet` output.
+
+- [ ] **Step 9: Smoke-test the CLI**
+
+```bash
+./imv verify --help
+```
+
+Expected: `--no-cache` flag still present in the help output; no runtime errors from the binary starting up.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/verifier/cache.go internal/verifier/cache_test.go internal/verifier/verifier.go
+git commit -m "$(cat <<'EOF'
+refactor(verifier): stateless cache persist (no long-lived handle)
+
+Replaces the long-lived O_APPEND cache write handle with periodic
+wholesale snapshots (tmp + rename) from an in-memory map. Cadence:
+initial persist after intersection, every 30s during the verify loop
+via Record, once at end of year. No file handle is held open between
+persists — fixes cross-machine cache resets on SMB/CIFS where the
+long-lived handle interacted badly with handle-based locking,
+credential re-auths, and permission drift.
+
+Cache struct loses mu/file/buf/lastFlush; gains lastPersist/dirty.
+Compact -> Persist, AppendVerified -> Record, Flush/Close removed.
+File format (TSV v1) and flag surface (--no-cache) unchanged; old
+cache files continue to load transparently.
+
+Spec: docs/superpowers/specs/2026-04-19-verify-cache-stateless-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+Ran against the spec:
+
+- **Spec §1 (Cache type before/after):** Task 2 Step 3 rewrites the struct to match exactly (`path`, `entries`, `lastPersist`, `dirty`).
+- **Spec §2 (Per-year lifecycle):** Load + intersect + initial Persist covered in Task 2 Step 4 Edit 3. Verify loop Record-with-cadence covered by `Record` in Step 3 and Edit 4. End-of-year Persist covered in Edit 2.
+- **Spec §3 (Persist operation):** Implemented in Step 3, reusing `renameOverwrite`.
+- **Spec §4 (Methods table):** Every row accounted for — `Load`/`Lookup`/`Matches`/`Entries` unchanged in Step 3; `Compact`→`Persist` and `AppendVerified`→`Record` covered; `Flush`/`Close` removed.
+- **Spec §5 (Verifier changes):** Task 2 Step 4 covers all three edits; Task 1 handles the debug-log removals for this file.
+- **Spec §6 (Error handling):** `openYearCache` warnings already match; new end-of-year warning added in Edit 2; `Record` return errors surface via the existing `cache record failed` warning path in Edit 4.
+- **Spec §7 (Concurrency note):** No code change needed; comment on `Cache` in Step 3 documents the in-memory-map-plus-Persist shape.
+- **Spec §8 (Debug logging removal):** Task 1 covers end to end. Note: spec says "6 call sites (4 in cache.go, 2 in verifier.go)" — actual count is 14+2. Plan is accurate.
+- **Spec "Tests" section drops/additions:** covered in Task 2 Step 1. Every named test is handled (kept, deleted, or added).
+- **Spec "Integration" section:** existing tests remain correct. New "process dies between 30s ticks" test from the spec's wishlist is not added in this plan — call it out as a follow-up if the reviewer wants it.
+- **Spec "Open items for plan phase":** end-of-year persist placement is picked (Edit 2: inline after `verifySourceFiles`, before the err-return, gated on `dirty`). Per-year info-level log deferred as noted.
+
+Placeholder scan: no TBD/TODO, every code block has real code, every command has concrete expectations. No references to undefined types/methods.
+
+Type consistency: `Persist`, `Record`, `persistInterval`, `lastPersist`, `dirty` spelled identically across all tasks and tests.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-19-verify-cache-stateless.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-04-19-verify-cache-stateless-design.md
+++ b/docs/superpowers/specs/2026-04-19-verify-cache-stateless-design.md
@@ -1,0 +1,192 @@
+# Verify Cache — Stateless Persist Redesign
+
+**Date:** 2026-04-19
+**Status:** Approved, ready for planning
+**Scope:** `internal/verifier` cache subsystem. Removes the persistent `O_APPEND` write handle held for the duration of a year's verify; replaces it with periodic wholesale snapshots (tmp + rename) driven from an in-memory map. Also removes the `IMV_DEBUG` tracing helper added during the recent cross-FS firefight.
+
+## Motivation
+
+The current cache holds an open `O_APPEND|O_WRONLY` write handle for the entire duration of a year's verify (potentially hours on a 5 TB library). That handle is the source of recurring failures on shared/network storage:
+
+- Running verify on a second machine resets the cache repeatedly despite multiple attempted fixes around mtime precision, non-destructive copy fallbacks, and signal handling.
+- SMB/CIFS handle-based locking, credential re-auths, and mmap-like flush semantics all interact badly with long-held handles.
+- Permission and ownership drift between machines shows up as inability to reopen the compacted file for append, which silently disables the cache and triggers a full re-verify.
+
+An embedded DB (SQLite, bbolt) was considered but rejected: putting them on shared storage would replicate the same class of failures (SQLite lock files and WAL shards; bbolt mmap requirements) rather than fix them.
+
+The root problem is **the long-lived handle, not the file format**. Every persist being a fresh open-write-fsync-close-rename is the I/O pattern network filesystems are happiest with.
+
+## Goals
+
+- Verify run on machine B does not invalidate cache written by machine A on the same library.
+- No file handle into the cache file is held open longer than a single persist call.
+- Worst-case crash loses at most ~30 seconds of newly-verified entries for the current year.
+- Persist failure is never fatal: verify continues, the cache is memory-only for the rest of the run, next persist tick may succeed.
+- Simpler code: remove the mutex, the buffered append writer, the flush cadence plumbing, and the `IMV_DEBUG` helper.
+
+## Non-goals
+
+- Cross-machine cache merge (two machines running verify simultaneously on the same library is out of scope; last-writer-wins is acceptable).
+- Changing where the cache lives — stays at `<library>/<year>/.imv/verify.cache`.
+- Changing the on-disk file format — stays TSV v1. No migration required.
+- Changing the `--no-cache` flag or cache-hit semantics.
+- Removing the `v.logger.Warn(...)` operational warnings on cache failure; only the `debugLog`/`IMV_DEBUG` tracing goes.
+
+## Design
+
+### 1. Cache type
+
+Before:
+
+```go
+type Cache struct {
+    mu        sync.Mutex
+    path      string
+    entries   map[string]Entry
+    file      *os.File
+    buf       *bufio.Writer
+    lastFlush time.Time
+}
+```
+
+After:
+
+```go
+type Cache struct {
+    path        string
+    entries     map[string]Entry
+    lastPersist time.Time
+    dirty       bool
+}
+```
+
+The mutex is gone because the verify loop is single-goroutine and the signal handler that used to close concurrently was already removed (commit 7714aa2). The persistent `file`/`buf`/`lastFlush` fields are gone because no handle survives past a persist call.
+
+### 2. Per-year lifecycle
+
+1. **Load** (`Load(path)`): read the whole file into `entries` map. Unchanged from today. File is closed before `Load` returns.
+2. **Intersect**: for each on-disk file walked by `ListSourceFiles`, keep only cache entries whose `size + mtime_ns + hash_algo` still match the current `FileInfo`. Unchanged from today.
+3. **Initial persist** (`Persist()`): write tmp, fsync tmp, rename over final. This is what today's `Compact` does minus the "reopen for append" step. Sets `lastPersist = now`, `dirty = false`.
+4. **Verify loop** — for each file:
+    - On cache hit: no map mutation; loop continues.
+    - On miss resulting in `Verified`: `entries[relPath] = entry; dirty = true`. After the mutation, if `dirty && time.Since(lastPersist) > 30s` → `Persist()`.
+    - On `Fixed`, `Inconsistent`, `Error`: no cache mutation (unchanged policy).
+5. **End of year** (deferred, runs on any exit from the year including error paths): if `dirty` → final `Persist()`. Runs whether or not the 30s timer would have fired. This matches today's `defer Close()` behavior of flushing buffered state on error, so a year that fails partway through still records the work completed before the failure.
+
+No `O_APPEND` handle exists at any point between persists.
+
+### 3. Persist operation
+
+```
+func (c *Cache) Persist() error {
+    // mkdir -p c.path's parent
+    // write c.path + ".tmp" with header + all entries, buffered
+    // flush buffer; fsync tmp; close tmp
+    // rename tmp over c.path (with the existing remove+rename fallback
+    //   for SMB/CIFS/FUSE)
+    // lastPersist = time.Now(); dirty = false
+}
+```
+
+This reuses the atomic-rename dance already in `Compact` — including the `renameOverwrite` helper that falls back to `remove + rename` when the destination filesystem refuses to overwrite.
+
+### 4. Methods
+
+| Before | After | Notes |
+|---|---|---|
+| `Load(path) (*Cache, error)` | `Load(path) (*Cache, error)` | Unchanged semantics. Returns a cache with `entries` populated; `lastPersist` zero-valued. |
+| `Lookup`, `Matches`, `Entries` | unchanged | Pure map reads. Remain nil-safe. |
+| `Compact(keep) error` | `Persist() error` | Replaces Compact. Callers that previously did `Compact(keep)` now assign `c.entries = keep` directly then call `Persist()`. Nil-safe. |
+| `AppendVerified(e Entry) error` | `Record(e Entry) error` | Renamed to reflect that it records in-memory, no I/O. Inserts into map, sets dirty, and triggers `Persist()` if the 30s interval has elapsed. Path validation (reject `\t`/`\n`) is preserved. Nil-safe. |
+| `Flush() error` | removed | No buffered-write state to flush. |
+| `Close() error` | removed | No handle to close. The end-of-year final persist is an explicit call in the verify flow, not hidden in a Close. |
+
+All remaining methods are nil-safe so callers don't need to check.
+
+### 5. Verifier changes
+
+`internal/verifier/verifier.go`:
+
+- `openYearCache` assigns the intersected map to `c.entries` and calls `Persist()` (in place of today's `Compact(keep)`).
+- `verifySourceFiles` loop:
+    - Replaces `yc.AppendVerified(...)` calls with `yc.Record(...)`.
+    - Adds a `defer yc.Persist()` (gated on `dirty`) at the year-level call site so the final write happens even when the verify loop exits between 30s ticks. The simplest placement is in the `Verify()` loop, right after the `openYearCache` call, alongside whatever `Close` used to be.
+- Drops the helper's `Close()` calls (Close no longer exists).
+- Drops all `debugLog(...)` calls (2 sites in this file).
+
+`internal/verifier/cache.go`:
+
+- Drops the `debugLog` function and all 4 call sites.
+- Drops the `IMV_DEBUG` env var entirely — no code path reads it anymore.
+- Drops `cacheFlushInterval = 10 * time.Second`; introduces `persistInterval = 30 * time.Second`.
+
+### 6. Error handling
+
+Cache is a performance optimization, never a correctness gate. Verify's exit code remains determined by `result.Inconsistent` and `result.Errors` only.
+
+| Failure | Action |
+|---|---|
+| `mkdir .imv/` fails | Warn once per year-iteration; disable cache for this year; continue. |
+| `Load` read error | Warn; treat as empty cache; continue. |
+| Malformed line during `Load` | Skip line; count for summary; continue parsing. |
+| `Persist` during loop fails | Warn once per year-iteration; **keep in-memory map intact**; retry on next 30s tick or at end of year. |
+| `Persist` at end of year fails | Warn; do not fail `Verify()`. |
+| Persistent failures across all ticks | Effectively same as `--no-cache` for this run; next run loads whatever was successfully persisted before things broke. |
+
+The "warn once per year-iteration" rule prevents a flaky filesystem from flooding stderr.
+
+### 7. Concurrency note
+
+The verify loop is sequential per year today, and this design assumes that. No mutex is added. If verify is ever parallelized within a year, `Record` and `Persist` will need coordination — flagged here so it isn't missed later.
+
+### 8. Debug logging removal
+
+Single-purpose cleanup piggy-backing on this change:
+
+- Remove the `debugLog(format string, args ...any)` helper in `cache.go`.
+- Remove all 6 call sites (4 in `cache.go`, 2 in `verifier.go`).
+- Remove the `IMV_DEBUG` environment variable from the codebase. No documentation references it today.
+- Keep every `v.logger.Warn(...)` call in the cache paths — those are user-facing operational logs.
+
+## Tests
+
+### Drops from `internal/verifier/cache_test.go`
+
+- Append-after-compact tests (`AppendVerified` flow with open handle).
+- `Flush` cadence tests (injected clock, two appends within 10s → one fsync).
+- `Close` idempotency and nil-safety tests.
+- Mutex-guarded concurrent-close tests (if present).
+
+### Additions
+
+- `Persist` happy path: entries in memory → file contents match (header + lines).
+- `Persist` called twice: second call overwrites first cleanly; no leftover tmp file on success.
+- `Record` then `Persist`: entry present in file after persist; entry absent from file before persist.
+- `Record` within 30s of last persist: no file write occurs.
+- `Record` after 30s since last persist: `Persist` triggered; file updated.
+- Simulated rename failure (pre-existing file that refuses overwrite): verify the `renameOverwrite` fallback still applies; original file intact on failure.
+- Path with `\t` or `\n`: `Record` rejects with error; map unchanged; file unchanged.
+- Nil receiver: `Record`, `Persist`, `Lookup` all safe.
+
+### Integration (`internal/integration_test.go`)
+
+- Existing cache integration tests adapt by dropping any assertions on the presence of an open handle after compact. Main flow is unchanged:
+    - First run populates `2024/.imv/verify.cache`.
+    - Second run hits cache; counts identical; no exiftool calls for cached files.
+    - Touch file mtime → that file misses; others hit.
+    - Delete file → compaction drops its entry.
+    - `--no-cache` → no file created or modified.
+    - `--fix` flow → misplaced file moved; no entry written; next run re-verifies and records.
+    - `--year 2024` → only that year's cache touched.
+    - Algo switch → all entries miss; file rewritten with new algo on next persist.
+    - Garbage cache file → load returns empty; verify proceeds.
+- New: simulate "process dies between 30s ticks" (do not call the final end-of-year persist). Verify on next run: only entries from prior ticks are present; entries written after the last tick are not.
+
+## Rollout
+
+Single commit (or small series) on a feature branch. No on-disk format change, no migration path, no flag change. Existing cache files continue to load; first `Persist()` of a year rewrites in the same format.
+
+## Open items for the plan phase
+
+- Exact placement of the end-of-year `Persist()` call — inside `openYearCache`'s defer, in a new helper, or explicit at the `Verify()` loop body. Planner's choice; any of the three is fine.
+- Whether to emit a per-year info-level log line with persist counts (e.g. "cache for 2024: 3 snapshots written, 240 new entries"). Low priority; defer if it complicates the first cut.

--- a/internal/verifier/cache.go
+++ b/internal/verifier/cache.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/askolesov/image-vault/internal/defaults"
@@ -19,7 +18,7 @@ const (
 	cacheDirName       = ".imv"
 	cacheFormatVersion = "v1"
 	cacheFieldSep      = "\t"
-	cacheFlushInterval = 10 * time.Second
+	persistInterval    = 30 * time.Second
 )
 
 // Entry is a single cached verification record.
@@ -31,18 +30,18 @@ type Entry struct {
 	VerifiedAt int64
 }
 
-// Cache holds per-year verification cache state.
+// Cache holds per-year verification cache state. It is an in-memory
+// map[string]Entry plus a Persist method that atomically rewrites the
+// whole file. No file handle is held open between persists — this is
+// the key property that keeps the cache stable across cross-filesystem
+// scenarios (SMB/CIFS, FUSE, permission drift between machines).
+//
 // A nil *Cache is a valid no-op receiver for every method.
-// The mutex guards concurrent access from a signal handler goroutine
-// (which may Close the cache on SIGINT) and the main verify goroutine
-// (which Appends and Flushes).
 type Cache struct {
-	mu        sync.Mutex
-	path      string
-	entries   map[string]Entry
-	file      *os.File
-	buf       *bufio.Writer
-	lastFlush time.Time
+	path        string
+	entries     map[string]Entry
+	lastPersist time.Time
+	dirty       bool
 }
 
 // isSkippableInLibrary reports whether a filename should be silently skipped
@@ -77,9 +76,12 @@ func NewEntry(relPath string, fi os.FileInfo, algo string) Entry {
 	}
 }
 
-// Load parses the cache file at path (if present) and returns a populated Cache.
-// A missing file is not an error. Malformed lines are silently skipped.
-// The returned Cache is not yet open for append — call Compact first.
+// Load parses the cache file at path (if present) and returns a populated
+// Cache. A missing file is not an error. Malformed lines are silently
+// skipped. The returned Cache has lastPersist zero-valued, so the first
+// Record after Load will trigger a persist; callers that want to control
+// initial persist timing (e.g. openYearCache after intersection) should
+// call Persist explicitly.
 func Load(path string) (*Cache, error) {
 	c := &Cache{
 		path:    path,
@@ -152,10 +154,12 @@ func (c *Cache) Entries() map[string]Entry {
 	return out
 }
 
-// Compact rewrites the cache file to contain only the given keep entries,
-// then opens it for append. Uses tmp + fsync + rename for atomicity.
-// Leaves the original file untouched on any failure.
-func (c *Cache) Compact(keep map[string]Entry) error {
+// Persist atomically rewrites the on-disk cache file from the current
+// in-memory entries. Uses tmp + fsync + rename (with remove+rename
+// fallback for filesystems that refuse overwrite). On success: clears
+// dirty and updates lastPersist. On failure: leaves the original file
+// untouched and the in-memory map unchanged.
+func (c *Cache) Persist() error {
 	if c == nil {
 		return nil
 	}
@@ -176,7 +180,7 @@ func (c *Cache) Compact(keep map[string]Entry) error {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("write cache header: %w", err)
 	}
-	for _, e := range keep {
+	for _, e := range c.entries {
 		if _, err := fmt.Fprintln(writer, formatCacheLine(e)); err != nil {
 			_ = tmp.Close()
 			_ = os.Remove(tmpPath)
@@ -203,89 +207,30 @@ func (c *Cache) Compact(keep map[string]Entry) error {
 		return fmt.Errorf("rename cache: %w", err)
 	}
 
-	c.entries = make(map[string]Entry, len(keep))
-	maps.Copy(c.entries, keep)
-
-	f, err := os.OpenFile(c.path, os.O_APPEND|os.O_WRONLY, 0o644)
-	if err != nil {
-		return fmt.Errorf("reopen cache for append: %w", err)
-	}
-	c.file = f
-	c.buf = bufio.NewWriter(f)
-	c.lastFlush = time.Now()
-
+	c.lastPersist = time.Now()
+	c.dirty = false
 	return nil
 }
 
-// AppendVerified records a verified file. Paths containing tab or newline
-// are rejected (they would corrupt the TSV format). Flush + fsync if the
-// time since last flush exceeds cacheFlushInterval.
-func (c *Cache) AppendVerified(e Entry) error {
+// Record inserts e into the in-memory cache. If persistInterval has
+// elapsed since lastPersist, Record also calls Persist as a side effect.
+// Paths containing tab or newline are rejected (they would corrupt the
+// TSV format) — the map is not mutated and no persist happens in that
+// case.
+func (c *Cache) Record(e Entry) error {
 	if c == nil {
-		return nil
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.file == nil || c.buf == nil {
 		return nil
 	}
 	if strings.ContainsAny(e.RelPath, "\t\n") {
 		return fmt.Errorf("cache: path contains tab or newline: %q", e.RelPath)
 	}
-	if _, err := fmt.Fprintln(c.buf, formatCacheLine(e)); err != nil {
-		return fmt.Errorf("append cache line: %w", err)
-	}
 	c.entries[e.RelPath] = e
+	c.dirty = true
 
-	if time.Since(c.lastFlush) > cacheFlushInterval {
-		return c.flushLocked()
+	if time.Since(c.lastPersist) > persistInterval {
+		return c.Persist()
 	}
 	return nil
-}
-
-// Flush empties the buffer and fsyncs.
-func (c *Cache) Flush() error {
-	if c == nil {
-		return nil
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.flushLocked()
-}
-
-// flushLocked performs the flush work; caller must hold c.mu.
-func (c *Cache) flushLocked() error {
-	if c.file == nil || c.buf == nil {
-		return nil
-	}
-	if err := c.buf.Flush(); err != nil {
-		return fmt.Errorf("flush cache buffer: %w", err)
-	}
-	if err := c.file.Sync(); err != nil {
-		return fmt.Errorf("fsync cache: %w", err)
-	}
-	c.lastFlush = time.Now()
-	return nil
-}
-
-// Close flushes and closes the cache file. Idempotent.
-func (c *Cache) Close() error {
-	if c == nil {
-		return nil
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.file == nil {
-		return nil
-	}
-	flushErr := c.flushLocked()
-	closeErr := c.file.Close()
-	c.file = nil
-	c.buf = nil
-	if flushErr != nil {
-		return flushErr
-	}
-	return closeErr
 }
 
 // renameOverwrite renames src over dst. POSIX rename(2) overwrites on the

--- a/internal/verifier/cache.go
+++ b/internal/verifier/cache.go
@@ -89,22 +89,15 @@ func Load(path string) (*Cache, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			debugLog("load: %q missing; starting empty", path)
 			return c, nil
 		}
-		debugLog("load: open %q failed: %v", path, err)
 		return nil, fmt.Errorf("open cache: %w", err)
 	}
 	defer func() { _ = f.Close() }()
 
-	if fi, err := f.Stat(); err == nil {
-		debugLog("load: %q size=%d mtime=%s", path, fi.Size(), fi.ModTime().Format(time.RFC3339))
-	}
-
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 
-	var malformed int
 	for scanner.Scan() {
 		line := scanner.Text()
 		if line == "" || strings.HasPrefix(line, "#") {
@@ -112,17 +105,14 @@ func Load(path string) (*Cache, error) {
 		}
 		e, ok := parseCacheLine(line)
 		if !ok {
-			malformed++
 			continue
 		}
 		c.entries[e.RelPath] = e
 	}
 	if err := scanner.Err(); err != nil {
-		debugLog("load: scan error: %v", err)
 		return c, fmt.Errorf("scan cache: %w", err)
 	}
 
-	debugLog("load ok: %q entries=%d malformed=%d", path, len(c.entries), malformed)
 	return c, nil
 }
 
@@ -169,17 +159,14 @@ func (c *Cache) Compact(keep map[string]Entry) error {
 	if c == nil {
 		return nil
 	}
-	debugLog("compact start: path=%q keep=%d", c.path, len(keep))
 
 	if err := os.MkdirAll(filepath.Dir(c.path), 0o755); err != nil {
-		debugLog("compact: mkdir failed: %v", err)
 		return fmt.Errorf("mkdir cache dir: %w", err)
 	}
 
 	tmpPath := c.path + ".tmp"
 	tmp, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 	if err != nil {
-		debugLog("compact: open tmp %q failed: %v", tmpPath, err)
 		return fmt.Errorf("create tmp cache: %w", err)
 	}
 
@@ -210,10 +197,8 @@ func (c *Cache) Compact(keep map[string]Entry) error {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("close tmp cache: %w", err)
 	}
-	debugLog("compact: tmp written ok at %q", tmpPath)
 
 	if err := renameOverwrite(tmpPath, c.path); err != nil {
-		debugLog("compact: renameOverwrite failed: %v", err)
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("rename cache: %w", err)
 	}
@@ -223,13 +208,11 @@ func (c *Cache) Compact(keep map[string]Entry) error {
 
 	f, err := os.OpenFile(c.path, os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
-		debugLog("compact: reopen for append failed: %v", err)
 		return fmt.Errorf("reopen cache for append: %w", err)
 	}
 	c.file = f
 	c.buf = bufio.NewWriter(f)
 	c.lastFlush = time.Now()
-	debugLog("compact ok: path=%q entries=%d", c.path, len(c.entries))
 
 	return nil
 }
@@ -312,23 +295,10 @@ func (c *Cache) Close() error {
 // cache, not durable state.
 func renameOverwrite(src, dst string) error {
 	if err := os.Rename(src, dst); err == nil {
-		debugLog("rename: %q -> %q ok", src, dst)
 		return nil
-	} else {
-		debugLog("rename failed: %q -> %q: %v; retrying with remove", src, dst, err)
 	}
 	_ = os.Remove(dst)
 	return os.Rename(src, dst)
-}
-
-// debugLog writes a diagnostic line to stderr when IMV_DEBUG is set. Used
-// to trace cache-path decisions without polluting normal output. The test
-// suite leaves IMV_DEBUG unset, so output is silent during CI.
-func debugLog(format string, args ...any) {
-	if os.Getenv("IMV_DEBUG") == "" {
-		return
-	}
-	_, _ = fmt.Fprintf(os.Stderr, "[imv-debug] "+format+"\n", args...)
 }
 
 func writeCacheHeader(w *bufio.Writer) error {

--- a/internal/verifier/cache_test.go
+++ b/internal/verifier/cache_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -112,7 +111,7 @@ func TestCacheLoad_EmbeddedNewlineSplitsLine(t *testing.T) {
 	// The first fragment is malformed and dropped. The second fragment
 	// happens to look like a valid record with path="part2". This is
 	// benign: "part2" won't exist on disk, so compaction drops it.
-	// Write-side protection against this lives in AppendVerified.
+	// Write-side protection against this lives in Record.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "cache")
 	content := "part1\npart2\t100\t1\tmd5\t10\n"
@@ -189,174 +188,171 @@ func TestCacheMatches_CrossHostSMBScenario(t *testing.T) {
 		"cache entry written at second precision should match ns-precision disk mtime")
 }
 
-func TestCacheCompact_HappyPath(t *testing.T) {
+// TestCachePersist_HappyPath: Persist writes the header and all in-memory
+// entries to disk, creating the parent .imv/ directory if needed.
+func TestCachePersist_HappyPath(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".imv", "verify.cache")
-	// Pre-existing content that should be replaced entirely.
-	writeCacheFile(t, path,
-		"old\t1\t1\tmd5\t1\n"+
-			"kept\t100\t500\tmd5\t999\n")
 
 	c, err := Load(path)
 	require.NoError(t, err)
+	c.entries["a.jpg"] = Entry{RelPath: "a.jpg", Size: 100, MtimeNs: 500, HashAlgo: "md5", VerifiedAt: 999}
+	c.dirty = true
 
-	keep := map[string]Entry{
-		"kept": {RelPath: "kept", Size: 100, MtimeNs: 500, HashAlgo: "md5", VerifiedAt: 999},
-	}
-	require.NoError(t, c.Compact(keep))
-	require.NoError(t, c.Close())
+	require.NoError(t, c.Persist())
 
-	// Reload and check content.
+	// Reload to confirm on-disk content.
 	c2, err := Load(path)
 	require.NoError(t, err)
 	assert.Len(t, c2.Entries(), 1)
-	e, ok := c2.Lookup("kept")
+	got, ok := c2.Lookup("a.jpg")
 	require.True(t, ok)
-	assert.Equal(t, int64(100), e.Size)
+	assert.Equal(t, int64(100), got.Size)
 
-	// Ensure old entry is gone.
-	_, ok = c2.Lookup("old")
-	assert.False(t, ok)
+	// dirty flag cleared after a successful persist.
+	assert.False(t, c.dirty)
 }
 
-func TestCacheCompact_EmptyKeep(t *testing.T) {
+// TestCachePersist_OverwritesExistingFile: second Persist replaces first
+// cleanly — regression for the cross-machine "rename: file exists" case.
+func TestCachePersist_OverwritesExistingFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".imv", "verify.cache")
-	writeCacheFile(t, path, "old\t1\t1\tmd5\t1\n")
 
-	c, err := Load(path)
+	c1, err := Load(path)
 	require.NoError(t, err)
-	require.NoError(t, c.Compact(map[string]Entry{}))
-	require.NoError(t, c.Close())
+	c1.entries["a.jpg"] = Entry{RelPath: "a.jpg", Size: 1, MtimeNs: 1, HashAlgo: "md5", VerifiedAt: 1}
+	c1.dirty = true
+	require.NoError(t, c1.Persist())
 
 	c2, err := Load(path)
 	require.NoError(t, err)
-	assert.Empty(t, c2.Entries())
+	c2.entries = map[string]Entry{
+		"b.jpg": {RelPath: "b.jpg", Size: 2, MtimeNs: 2, HashAlgo: "md5", VerifiedAt: 2},
+	}
+	c2.dirty = true
+	require.NoError(t, c2.Persist())
+
+	c3, err := Load(path)
+	require.NoError(t, err)
+	_, hasA := c3.Lookup("a.jpg")
+	_, hasB := c3.Lookup("b.jpg")
+	assert.False(t, hasA, "old entry should have been overwritten")
+	assert.True(t, hasB, "new entry should be present")
 }
 
-func TestCacheCompact_CreatesDirIfMissing(t *testing.T) {
+// TestCachePersist_EmptyWritesHeader: persisting with no entries yields
+// a file with just the header comment.
+func TestCachePersist_EmptyWritesHeader(t *testing.T) {
 	dir := t.TempDir()
-	// Deep nested cache path where .imv/ doesn't exist yet.
+	path := filepath.Join(dir, ".imv", "verify.cache")
+
+	c, err := Load(path)
+	require.NoError(t, err)
+	require.NoError(t, c.Persist())
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(content), "#"), "should start with comment header")
+	assert.Contains(t, string(content), "verify-cache v1")
+}
+
+// TestCachePersist_CreatesDirIfMissing: .imv/ is created as needed.
+func TestCachePersist_CreatesDirIfMissing(t *testing.T) {
+	dir := t.TempDir()
 	path := filepath.Join(dir, "2024", ".imv", "verify.cache")
 
 	c, err := Load(path)
 	require.NoError(t, err)
-	require.NoError(t, c.Compact(map[string]Entry{
-		"file": {RelPath: "file", Size: 10, MtimeNs: 5, HashAlgo: "md5", VerifiedAt: 1},
-	}))
-	require.NoError(t, c.Close())
+	c.entries["file"] = Entry{RelPath: "file", Size: 10, MtimeNs: 5, HashAlgo: "md5", VerifiedAt: 1}
+	c.dirty = true
+	require.NoError(t, c.Persist())
 
 	_, err = os.Stat(path)
 	assert.NoError(t, err)
 }
 
-func TestCacheAppendVerified_PersistsAfterFlush(t *testing.T) {
+// TestCacheRecord_InMemoryOnly: Record inserts into the map and flips
+// dirty, but does not write to disk when the persist interval has not
+// elapsed. Verify by checking the cache file does not exist yet.
+func TestCacheRecord_InMemoryOnly(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".imv", "verify.cache")
 
 	c, err := Load(path)
 	require.NoError(t, err)
-	require.NoError(t, c.Compact(map[string]Entry{}))
+	// Make Record think we persisted "just now" so its cadence check doesn't fire.
+	c.lastPersist = time.Now()
 
 	e := Entry{RelPath: "new", Size: 42, MtimeNs: 7, HashAlgo: "md5", VerifiedAt: 100}
-	require.NoError(t, c.AppendVerified(e))
-	require.NoError(t, c.Flush())
+	require.NoError(t, c.Record(e))
 
-	c2, err := Load(path)
-	require.NoError(t, err)
-	got, ok := c2.Lookup("new")
+	assert.True(t, c.dirty)
+	got, ok := c.Lookup("new")
 	require.True(t, ok)
 	assert.Equal(t, int64(42), got.Size)
+
+	// No file should exist on disk yet.
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err), "Record must not write to disk when interval has not elapsed")
 }
 
-func TestCacheAppendVerified_PersistsAfterClose(t *testing.T) {
+// TestCacheRecord_TriggersPersistAfterInterval: once persistInterval has
+// elapsed since lastPersist, Record triggers a Persist() as a side effect.
+func TestCacheRecord_TriggersPersistAfterInterval(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".imv", "verify.cache")
 
 	c, err := Load(path)
 	require.NoError(t, err)
-	require.NoError(t, c.Compact(map[string]Entry{}))
-	require.NoError(t, c.AppendVerified(Entry{RelPath: "x", Size: 1, MtimeNs: 1, HashAlgo: "md5", VerifiedAt: 1}))
-	require.NoError(t, c.Close())
+	// Pretend we last persisted an hour ago.
+	c.lastPersist = time.Now().Add(-1 * time.Hour)
 
+	e := Entry{RelPath: "new", Size: 1, MtimeNs: 1, HashAlgo: "md5", VerifiedAt: 1}
+	require.NoError(t, c.Record(e))
+
+	// File should exist and contain the entry.
 	c2, err := Load(path)
 	require.NoError(t, err)
-	_, ok := c2.Lookup("x")
-	assert.True(t, ok)
+	_, ok := c2.Lookup("new")
+	assert.True(t, ok, "Record should have triggered Persist after interval elapsed")
+
+	// lastPersist should be updated (near now), dirty cleared.
+	assert.WithinDuration(t, time.Now(), c.lastPersist, 5*time.Second)
+	assert.False(t, c.dirty)
 }
 
-func TestCacheAppendVerified_RejectsTabInPath(t *testing.T) {
+// TestCacheRecord_RejectsTabInPath: path containing \t is rejected
+// without mutating the map or writing to disk.
+func TestCacheRecord_RejectsTabInPath(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".imv", "verify.cache")
 
 	c, err := Load(path)
 	require.NoError(t, err)
-	require.NoError(t, c.Compact(map[string]Entry{}))
+	c.lastPersist = time.Now().Add(-1 * time.Hour) // would otherwise persist
 
-	err = c.AppendVerified(Entry{RelPath: "has\ttab", Size: 1, MtimeNs: 1, HashAlgo: "md5", VerifiedAt: 1})
+	err = c.Record(Entry{RelPath: "has\ttab", Size: 1, MtimeNs: 1, HashAlgo: "md5", VerifiedAt: 1})
 	assert.Error(t, err)
-	require.NoError(t, c.Close())
 
-	// File should not contain a corrupted record.
-	content, err := os.ReadFile(path)
-	require.NoError(t, err)
-	assert.NotContains(t, string(content), "has\ttab")
+	_, ok := c.Lookup("has\ttab")
+	assert.False(t, ok, "map must not contain the rejected entry")
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err), "no persist should have happened")
 }
 
-func TestCacheAppendVerified_RejectsNewlineInPath(t *testing.T) {
+// TestCacheRecord_RejectsNewlineInPath: same as above for \n.
+func TestCacheRecord_RejectsNewlineInPath(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".imv", "verify.cache")
 
 	c, err := Load(path)
 	require.NoError(t, err)
-	require.NoError(t, c.Compact(map[string]Entry{}))
 
-	err = c.AppendVerified(Entry{RelPath: "has\nnewline", Size: 1, MtimeNs: 1, HashAlgo: "md5", VerifiedAt: 1})
+	err = c.Record(Entry{RelPath: "has\nnewline", Size: 1, MtimeNs: 1, HashAlgo: "md5", VerifiedAt: 1})
 	assert.Error(t, err)
-	require.NoError(t, c.Close())
-}
-
-func TestCacheClose_Idempotent(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, ".imv", "verify.cache")
-
-	c, err := Load(path)
-	require.NoError(t, err)
-	require.NoError(t, c.Compact(map[string]Entry{}))
-	require.NoError(t, c.Close())
-	require.NoError(t, c.Close(), "second Close should be no-op")
-}
-
-// TestCacheConcurrentAppendAndClose models the SIGINT path: the main
-// goroutine calls AppendVerified in a tight loop while a second goroutine
-// (the signal handler) calls Close. Before the mutex was added, `go test
-// -race` would flag concurrent access to bufio.Writer and *os.File.
-func TestCacheConcurrentAppendAndClose(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, ".imv", "verify.cache")
-
-	c, err := Load(path)
-	require.NoError(t, err)
-	require.NoError(t, c.Compact(map[string]Entry{}))
-
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		// Hammer appends until Close is called and sets file=nil.
-		for i := range 10_000 {
-			_ = c.AppendVerified(Entry{
-				RelPath:    "sources/Dev (image)/2024-01-15/a.jpg",
-				Size:       1,
-				MtimeNs:    int64(i),
-				HashAlgo:   "md5",
-				VerifiedAt: time.Now().Unix(),
-			})
-		}
-	})
-
-	// Small sleep to let appends start, then close concurrently.
-	time.Sleep(1 * time.Millisecond)
-	assert.NoError(t, c.Close())
-	wg.Wait()
+	_, ok := c.Lookup("has\nnewline")
+	assert.False(t, ok)
 }
 
 func TestCacheNilReceiver_AllMethodsNoOp(t *testing.T) {
@@ -366,10 +362,8 @@ func TestCacheNilReceiver_AllMethodsNoOp(t *testing.T) {
 	assert.False(t, ok)
 	assert.False(t, c.Matches(Entry{}, nil, "md5"))
 	assert.Nil(t, c.Entries())
-	assert.NoError(t, c.Compact(nil))
-	assert.NoError(t, c.AppendVerified(Entry{}))
-	assert.NoError(t, c.Flush())
-	assert.NoError(t, c.Close())
+	assert.NoError(t, c.Record(Entry{}))
+	assert.NoError(t, c.Persist())
 }
 
 func TestCacheLoad_CorruptGarbageReturnsEmpty(t *testing.T) {
@@ -381,21 +375,6 @@ func TestCacheLoad_CorruptGarbageReturnsEmpty(t *testing.T) {
 	c, err := Load(path)
 	require.NoError(t, err)
 	assert.Empty(t, c.Entries())
-}
-
-func TestCacheCompactWritesHeader(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, ".imv", "verify.cache")
-
-	c, err := Load(path)
-	require.NoError(t, err)
-	require.NoError(t, c.Compact(map[string]Entry{}))
-	require.NoError(t, c.Close())
-
-	content, err := os.ReadFile(path)
-	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(string(content), "#"), "cache should start with a comment header")
-	assert.Contains(t, string(content), "verify-cache v1")
 }
 
 // TestRenameOverwrite_FallbackWhenEEXIST stubs os.Rename to fail once with
@@ -417,37 +396,6 @@ func TestRenameOverwrite_FallbackWhenEEXIST(t *testing.T) {
 	assert.Equal(t, "new", string(got))
 	_, err = os.Stat(src)
 	assert.True(t, os.IsNotExist(err), "src should be gone after rename")
-}
-
-// TestCompact_OverwritesExistingCache: ensures Compact replaces an existing
-// verify.cache file in the normal case — regression for the user-reported
-// "compact failed: rename: file exists" on cross-machine library access.
-func TestCompact_OverwritesExistingCache(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, ".imv", "verify.cache")
-
-	// First compaction creates the file.
-	c1, err := Load(path)
-	require.NoError(t, err)
-	require.NoError(t, c1.Compact(map[string]Entry{
-		"a.jpg": {RelPath: "a.jpg", Size: 1, MtimeNs: 1, HashAlgo: "md5", VerifiedAt: 1},
-	}))
-	require.NoError(t, c1.Close())
-
-	// Second compaction must overwrite the existing file on any FS.
-	c2, err := Load(path)
-	require.NoError(t, err)
-	require.NoError(t, c2.Compact(map[string]Entry{
-		"b.jpg": {RelPath: "b.jpg", Size: 2, MtimeNs: 2, HashAlgo: "md5", VerifiedAt: 2},
-	}))
-	require.NoError(t, c2.Close())
-
-	c3, err := Load(path)
-	require.NoError(t, err)
-	_, hasA := c3.Lookup("a.jpg")
-	_, hasB := c3.Lookup("b.jpg")
-	assert.False(t, hasA, "old entry should have been overwritten")
-	assert.True(t, hasB, "new entry should be present")
 }
 
 func TestCacheFilePath(t *testing.T) {

--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -169,27 +169,17 @@ func (v *Verifier) openYearCache(yearDir, year string, entries []FileEntry) *Cac
 		return nil
 	}
 
-	loaded := len(c.entries)
 	keep := make(map[string]Entry)
-	var matchMiss, lookupMiss int
 	for _, fe := range entries {
 		existing, ok := c.Lookup(fe.RelToYear)
 		if !ok {
-			lookupMiss++
 			continue
 		}
 		if !c.Matches(existing, fe.Info, v.cfg.HashAlgo) {
-			matchMiss++
-			debugLog("openYearCache: %s match miss: cached=(size=%d mtime=%d algo=%s) disk=(size=%d mtime=%d algo=%s)",
-				fe.RelToYear,
-				existing.Size, existing.MtimeNs, existing.HashAlgo,
-				fe.Info.Size(), fe.Info.ModTime().UnixNano(), v.cfg.HashAlgo)
 			continue
 		}
 		keep[fe.RelToYear] = existing
 	}
-	debugLog("openYearCache[%s]: loaded=%d entries=%d keep=%d lookupMiss=%d matchMiss=%d",
-		year, loaded, len(entries), len(keep), lookupMiss, matchMiss)
 
 	if err := c.Compact(keep); err != nil {
 		v.logger.Warn("cache for %s: compact failed: %v (continuing without cache)", year, err)

--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -77,10 +77,10 @@ func New(cfg Config, ext MetadataExtractor, logger *logging.Logger) (*Verifier, 
 // Verify runs integrity checks on the library and returns the result.
 //
 // No signal handling: a SIGINT terminates the process via Go's default
-// handler. The cache is flushed every ~cacheFlushInterval during normal
-// operation, so a crash loses at most that window of AppendVerified
-// entries. Anything un-flushed is regenerated on the next run — this is
-// a verification cache, not durable state.
+// handler. The cache is persisted every ~persistInterval during normal
+// operation plus once at end of year, so a crash loses at most that
+// window of recorded entries. Anything un-persisted is regenerated on
+// the next run — this is a verification cache, not durable state.
 func (v *Verifier) Verify() (*Result, error) {
 	years, err := library.ListYearsFiltered(v.cfg.LibraryPath, v.cfg.YearFilter)
 	if err != nil {
@@ -119,7 +119,15 @@ func (v *Verifier) Verify() (*Result, error) {
 		yc := v.openYearCache(yearDir, year, entries)
 
 		err = v.verifySourceFiles(year, entries, yc, i+1, len(years), result)
-		_ = yc.Close()
+		// End-of-year persist: runs on success and error paths alike, matching
+		// the old Close() semantics. Best-effort; failure is logged but does
+		// not fail Verify. openYearCache already did the initial persist, so
+		// this is a no-op if no new entries were recorded.
+		if yc != nil && yc.dirty {
+			if perr := yc.Persist(); perr != nil {
+				v.logger.Warn("cache for %s: end-of-year persist failed: %v", year, perr)
+			}
+		}
 		if err != nil {
 			return result, err
 		}
@@ -181,8 +189,10 @@ func (v *Verifier) openYearCache(yearDir, year string, entries []FileEntry) *Cac
 		keep[fe.RelToYear] = existing
 	}
 
-	if err := c.Compact(keep); err != nil {
-		v.logger.Warn("cache for %s: compact failed: %v (continuing without cache)", year, err)
+	c.entries = keep
+	c.dirty = true
+	if err := c.Persist(); err != nil {
+		v.logger.Warn("cache for %s: initial persist failed: %v (continuing without cache)", year, err)
 		return nil
 	}
 	return c
@@ -317,8 +327,8 @@ func (v *Verifier) verifySourceFiles(
 			// Path matches — hash is correct by definition since the expected
 			// path is built from the content hash
 			result.Verified++
-			if err := yc.AppendVerified(NewEntry(fe.RelToYear, fe.Info, v.cfg.HashAlgo)); err != nil {
-				v.logger.Warn("cache append failed for %s: %v", filePath, err)
+			if err := yc.Record(NewEntry(fe.RelToYear, fe.Info, v.cfg.HashAlgo)); err != nil {
+				v.logger.Warn("cache record failed for %s: %v", filePath, err)
 			}
 		} else {
 			// Path mismatch (wrong dir, wrong hash in filename, etc.)


### PR DESCRIPTION
## Summary

- **Stateless cache persist:** replaces the long-lived `O_APPEND` cache write handle with periodic wholesale snapshots (tmp + rename) driven from an in-memory map. Cadence: initial persist after intersection, every 30s during the verify loop (via `Record`), once at end of year. No file handle is held open between persists.
- **Fixes cross-machine cache resets** on SMB/CIFS where the long-lived handle interacted badly with handle-based locking, credential re-auths, and permission drift — the reason multiple prior fixes didn't stick.
- **Removes `IMV_DEBUG` tracing helper** added during the cross-FS firefight; no longer needed with the stateless design. User-facing `v.logger.Warn` operational logs are kept.

## What changed internally

- `Cache` struct: drops `mu`, `file`, `buf`, `lastFlush`; adds `lastPersist`, `dirty`.
- `Compact` → `Persist`, `AppendVerified` → `Record`, `Flush`/`Close` removed.
- File format (TSV v1) and flag surface (`--no-cache`) unchanged; existing cache files continue to load transparently.
- `cacheFlushInterval = 10s` → `persistInterval = 30s`.

## Test plan

- [x] `go test ./... -count=1 -race` — all green
- [x] `go vet ./...` — clean
- [x] `go build ./cmd/imv` — clean
- [x] `imv verify --help` — `--no-cache` flag still present
- [ ] Manual: run `imv verify` on the real library across two machines (the scenario that kept resetting the cache) and confirm second machine hits cache on its second run

## Spec / plan

- Spec: \`docs/superpowers/specs/2026-04-19-verify-cache-stateless-design.md\`
- Plan: \`docs/superpowers/plans/2026-04-19-verify-cache-stateless.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)