### PR TITLE
fix(verifier): honor FailFast on path mismatches

### DIFF
--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -345,6 +345,8 @@ func (v *Verifier) verifySourceFiles(
 					result.Fixed++
 					// Deliberately not caching fixed files — they'll re-verify next run.
 				}
+			} else if v.cfg.FailFast {
+				return fmt.Errorf("path mismatch: %s should be at %s", absActual, absExpected)
 			}
 		}
 	}

--- a/internal/verifier/verifier_test.go
+++ b/internal/verifier/verifier_test.go
@@ -221,6 +221,36 @@ func TestVerifyPathMismatch(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestVerifyPathMismatchFailFast: with FailFast=true and Fix=false, the first
+// path mismatch must abort Verify instead of continuing through the rest of
+// the library. Regression test for a bug where the path-mismatch branch was
+// the only inconsistency site that ignored v.cfg.FailFast.
+func TestVerifyPathMismatchFailFast(t *testing.T) {
+	libDir := t.TempDir()
+
+	// Two files at a wrong-but-structurally-valid device dir. Default
+	// fakeExtractor returns TestMake/TestModel metadata, so the expected
+	// path for each file lives under a different device dir — both are
+	// path mismatches.
+	wrongDir := filepath.Join(libDir, "2024", "sources", "OtherMake OtherModel (image)", "2024-01-15")
+	createTestFile(t, filepath.Join(wrongDir, "a.jpg"), "content-a")
+	createTestFile(t, filepath.Join(wrongDir, "b.jpg"), "content-b")
+
+	cfg := Config{
+		LibraryPath:   libDir,
+		SeparateVideo: false,
+		HashAlgo:      "md5",
+		FailFast:      true,
+		Randomize:     false,
+	}
+
+	v, err := New(cfg, &fakeExtractor{}, newTestLogger())
+	require.NoError(t, err)
+	result, err := v.Verify()
+	require.Error(t, err, "FailFast should surface an error on the first path mismatch")
+	assert.Equal(t, 1, result.Inconsistent, "FailFast should stop after the first inconsistency")
+}
+
 // TestVerifyHashMismatch: file at correct path but content changed so hash no longer matches filename
 func TestVerifyHashMismatch(t *testing.T) {
 	libDir := t.TempDir()


### PR DESCRIPTION
## Summary
- The path-mismatch branch in `verifySourceFiles` was the only inconsistency site ignoring `v.cfg.FailFast`, so `imv verify` processed the entire library after the first bad file instead of aborting early.
- Adds the missing `FailFast` check, gated on `!Fix` so `--fix` still repairs everything in one pass.
- Regression test (`TestVerifyPathMismatchFailFast`) places two mismatched files and asserts Verify stops after counting the first.

## Test plan
- [x] `go test ./internal/verifier/` — all tests pass including the new one
- [x] `go test ./...` — full suite passes
- [x] Manual repro: 3 mismatched files in a tempdir. Before fix: all 3 processed, exit 1. After fix: `1/3 (33%)` progress then abort, exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)