### PR TITLE
fix(import): count duplicates as Skipped under --move

### DIFF
--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -247,6 +247,48 @@ func TestImportMoveMode(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+// TestImportMoveDuplicate covers the case where the library already contains
+// the same file at the correct path. With --move, the source is still removed
+// (housekeeping) but nothing changes in the library, so the file should count
+// as Skipped, not Imported, and ProcessedBytes should not advance.
+func TestImportMoveDuplicate(t *testing.T) {
+	srcDir := t.TempDir()
+	libDir := t.TempDir()
+
+	srcFile := filepath.Join(srcDir, "photo.jpg")
+	createTestFile(t, srcFile, "jpeg-dup-content")
+
+	cfg := Config{
+		LibraryPath: libDir,
+		HashAlgo:    "md5",
+		Move:        true,
+	}
+
+	// Seed the library by running an initial import (copy mode).
+	seedImp, err := New(Config{LibraryPath: libDir, HashAlgo: "md5"}, &fakeExtractor{}, newTestLogger())
+	require.NoError(t, err)
+	seedResult, err := seedImp.ImportDir(srcDir)
+	require.NoError(t, err)
+	require.Equal(t, 1, seedResult.Imported)
+
+	// Source still exists (copy mode); now move-import the same source again.
+	_, err = os.Stat(srcFile)
+	require.NoError(t, err)
+
+	imp, err := New(cfg, &fakeExtractor{}, newTestLogger())
+	require.NoError(t, err)
+	result, err := imp.ImportDir(srcDir)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, result.Imported, "library is unchanged")
+	assert.Equal(t, 1, result.Skipped, "duplicate-on-move counts as skipped")
+	assert.Equal(t, int64(0), result.ProcessedBytes, "no bytes were transferred to the library")
+
+	// Source is removed despite being skipped — that's the point of --move.
+	_, err = os.Stat(srcFile)
+	assert.True(t, os.IsNotExist(err), "source must be removed under --move")
+}
+
 func TestImportDryRun(t *testing.T) {
 	srcDir := t.TempDir()
 	libDir := t.TempDir()

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -69,15 +69,12 @@ func TransferFile(source, target string, opts Options) (Action, error) {
 	_, statErr := os.Stat(target)
 	targetExists := statErr == nil
 
+	// Library unchanged → Skipped, even under --move (source is still removed).
 	if targetExists && opts.SkipCompare {
-		if opts.Move {
-			if opts.DryRun {
-				return ActionWouldMove, nil
-			}
+		if opts.Move && !opts.DryRun {
 			if err := os.Remove(source); err != nil {
 				return "", fmt.Errorf("remove source: %w", err)
 			}
-			return ActionMoved, nil
 		}
 		return ActionSkipped, nil
 	}
@@ -89,14 +86,10 @@ func TransferFile(source, target string, opts Options) (Action, error) {
 		}
 
 		if identical {
-			if opts.Move {
-				if opts.DryRun {
-					return ActionWouldMove, nil
-				}
+			if opts.Move && !opts.DryRun {
 				if err := os.Remove(source); err != nil {
 					return "", fmt.Errorf("remove source: %w", err)
 				}
-				return ActionMoved, nil
 			}
 			return ActionSkipped, nil
 		}

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -76,11 +76,12 @@ func TestTransferIdenticalExistsMove(t *testing.T) {
 
 	action, err := TransferFile(src, dst, Options{Move: true, NewHash: testHasher()})
 	require.NoError(t, err)
-	assert.Equal(t, ActionMoved, action)
+	// Library is unchanged, so the action is Skipped — but with --move
+	// the source is still removed as housekeeping.
+	assert.Equal(t, ActionSkipped, action)
 
-	// Source is gone
 	_, err = os.Stat(src)
-	assert.True(t, os.IsNotExist(err))
+	assert.True(t, os.IsNotExist(err), "source should still be removed under --move")
 }
 
 func TestTransferDifferentContentReplace(t *testing.T) {
@@ -232,11 +233,44 @@ func TestTransferIdenticalDryRunMove(t *testing.T) {
 
 	action, err := TransferFile(src, dst, Options{Move: true, DryRun: true, NewHash: testHasher()})
 	require.NoError(t, err)
-	assert.Equal(t, ActionWouldMove, action)
+	assert.Equal(t, ActionSkipped, action)
 
 	// Source should still exist (dry run)
 	_, err = os.Stat(src)
 	assert.NoError(t, err)
+}
+
+func TestTransferSkipCompareExistsMove(t *testing.T) {
+	dir := t.TempDir()
+	// Different content — but SkipCompare trusts the target without hashing,
+	// so the library is treated as already correct.
+	src := writeFile(t, dir, "src/photo.jpg", "src-content")
+	dst := writeFile(t, dir, "dst/photo.jpg", "dst-content")
+
+	action, err := TransferFile(src, dst, Options{Move: true, SkipCompare: true})
+	require.NoError(t, err)
+	assert.Equal(t, ActionSkipped, action)
+
+	_, err = os.Stat(src)
+	assert.True(t, os.IsNotExist(err), "source should be removed under --move")
+
+	// Destination is untouched.
+	data, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "dst-content", string(data))
+}
+
+func TestTransferSkipCompareDryRunMove(t *testing.T) {
+	dir := t.TempDir()
+	src := writeFile(t, dir, "src/photo.jpg", "src-content")
+	dst := writeFile(t, dir, "dst/photo.jpg", "dst-content")
+
+	action, err := TransferFile(src, dst, Options{Move: true, DryRun: true, SkipCompare: true})
+	require.NoError(t, err)
+	assert.Equal(t, ActionSkipped, action)
+
+	_, err = os.Stat(src)
+	assert.NoError(t, err, "source must remain on dry-run")
 }
 
 func TestCompareFilesNonexistent(t *testing.T) {


### PR DESCRIPTION
## Summary

- `imv import --move` over an already-imported source no longer counts unchanged-library files as `Imported`. They're counted as `Skipped`, and `ProcessedBytes` no longer advances for them.
- Source files are still removed (the point of `--move`); only the bookkeeping changes.
- Same fix applies to the `--no-verify` (SkipCompare) path and to `--dry-run`.

## Why

Today, when target exists with identical content (or under `--no-verify`), `transfer.TransferFile` removes the source and returns `ActionMoved` / `ActionWouldMove`. The importer maps those to `result.Imported++` and adds source bytes to `ProcessedBytes` — so re-running `--move` over an already-imported tree shows up as if everything was newly imported. The library was unchanged; the counter shouldn't say otherwise.

## Approach

Broaden `ActionSkipped` to mean "library unchanged" rather than "nothing happened to either side". Four branches in `transfer.go` flip from `ActionMoved`/`ActionWouldMove` → `ActionSkipped`:

| Condition | Before | After |
|---|---|---|
| target exists + `SkipCompare` + `--move` | `ActionMoved` | `ActionSkipped` |
| target exists + `SkipCompare` + `--move` + `--dry-run` | `ActionWouldMove` | `ActionSkipped` |
| target exists + identical + `--move` | `ActionMoved` | `ActionSkipped` |
| target exists + identical + `--move` + `--dry-run` | `ActionWouldMove` | `ActionSkipped` |

`ActionMoved` / `ActionWouldMove` are still in use for fresh-target moves. The importer's switch already routes `ActionSkipped` to `result.Skipped++` and adds nothing to `ProcessedBytes`, so no code change there.

## Test plan

- [x] `go test ./...` passes
- [x] `make lint` passes
- [x] Updated `TestTransferIdenticalExistsMove` / `TestTransferIdenticalDryRunMove` to expect `ActionSkipped` and verify source-removal semantics still hold
- [x] Added `TestTransferSkipCompareExistsMove` / `TestTransferSkipCompareDryRunMove` (previously untested branches)
- [x] Added `TestImportMoveDuplicate` covering end-to-end: `Imported=0`, `Skipped=1`, `ProcessedBytes=0`, source removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)