### PR TITLE
feat(verifier): allow undated/ at vault root

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ No config files — the library is defined by its directory layout:
     processed/        # freeform, not validated
   2025/
     ...
+  undated/            # freeform, not validated; for files with no year
 ```
 
 Naming conventions:
@@ -57,6 +58,8 @@ Naming conventions:
 - **Sidecars** (`.xmp`, `.yaml`, `.json`) — placed next to their primary file
 
 Files with no EXIF make/model go to `Unknown (<type>)/`. Videos get separate device dirs by default.
+
+Use `undated/` at the vault root for files with no usable year, or that you don't want filed by year. Freeform inside, not validated. Optional — only created when you need it.
 
 ## Commands
 

--- a/docs/superpowers/specs/2026-04-26-undated-root-dir-design.md
+++ b/docs/superpowers/specs/2026-04-26-undated-root-dir-design.md
@@ -1,0 +1,100 @@
+# `undated/` Root Directory
+
+## Problem
+
+The vault layout requires every file to live under a year directory (`YYYY/`).
+Some files have no usable year — no EXIF date, no reliable filesystem date — or
+the user simply doesn't want to file them by year. Today there is no convention
+for these, and `verify` warns on any non-year directory at the vault root.
+
+## Goal
+
+Allow a single freeform directory `undated/` at the vault root for media that
+has no year, or that the user deliberately wants to keep outside the
+year-based hierarchy.
+
+## Non-Goals
+
+- No per-year `undated/` (the year-level layout is unchanged).
+- No config file or allowlist mechanism. The name is fixed.
+- No `import` integration. `undated/` is populated manually by the user.
+- No centralization of well-known directory names. The existing inline-string
+  pattern in the verifier stays as-is.
+
+## Design
+
+### Convention
+
+```
+~/Photos/
+  2024/
+    sources/
+    sources-manual/
+    processed/
+  2025/
+    ...
+  undated/        # NEW — freeform, vault root only
+    ...           # anything; not validated
+```
+
+Rules:
+
+- Located at the vault root, sibling to year directories.
+- Contents are freeform: any file or directory layout is allowed inside.
+- `verify` does not recurse into `undated/` and does not warn about it.
+- The directory is optional. If absent, behavior is unchanged.
+
+### Behavior changes
+
+| Command | Behavior |
+|---|---|
+| `verify` | Treats `undated/` at vault root as allowed. Does not recurse. Other non-year root entries still warn as today. |
+| `verify --fix` | Same as `verify`. No fixes are applied to `undated/`. |
+| `verify --year YYYY` | Unaffected — `undated/` is not a year and is not selected by year filtering. |
+| `import` | Unchanged. Import always writes into year directories; it never reads from or writes to `undated/`. |
+| `tools remove-empty-dirs` | Unchanged. Operates on whatever path is given; if `undated/` happens to be empty it is removed (consistent with current behavior for any empty dir). |
+| `tools scan` / `diff` / `ext-count` | Unchanged. These already operate on arbitrary paths. |
+
+### Implementation
+
+One change in `internal/verifier/verifier.go::verifyLibraryRoot`: extend the
+existing root-level check so that, for directory entries that are not year
+directories, the literal name `"undated"` is allowed without warning. Files at
+the root and other unknown directories still warn / fail-fast as today.
+
+This mirrors the inline allowlist pattern already used in `verifyYearLevel`
+(`sources`, `processed`, `sources-manual`, `.imv`).
+
+No other source files change.
+
+### Documentation
+
+`README.md`:
+
+- Add `undated/` to the library structure tree at the vault root, sibling to
+  the year directories.
+- Add one short note to the structure section explaining the purpose:
+  "Use `undated/` at vault root for files with no year or that you don't want
+  filed by year. Freeform inside, not validated."
+
+## Testing
+
+Add to `internal/verifier/verifier_test.go`:
+
+1. Root contains `undated/` with arbitrary contents → verify passes with no
+   "unexpected directory" warning.
+2. Root contains `undated/` plus another non-year dir (e.g. `random/`) → only
+   `random/` warns; `undated/` is silent.
+3. `undated/` with `--fail-fast`: arbitrary contents inside do not cause
+   fail-fast to trip.
+
+Existing tests for unknown-name root dirs remain unchanged and must still pass.
+
+## Risks
+
+- **Name collision.** A user with an existing `undated/` directory containing
+  unrelated content would suddenly have it accepted by `verify`. This is the
+  intent; no data is moved or modified.
+- **Scope creep.** Future requests may push for additional well-known root
+  names or per-year `undated/`. Out of scope for this change; revisit if and
+  when needed.

--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -358,7 +358,8 @@ func (v *Verifier) verifySourceFiles(
 	return nil
 }
 
-// verifyLibraryRoot checks that the library root contains only year directories.
+// verifyLibraryRoot checks that the library root contains only year directories
+// and the optional freeform "undated" directory.
 func (v *Verifier) verifyLibraryRoot(result *Result) error {
 	entries, err := os.ReadDir(v.cfg.LibraryPath)
 	if err != nil {
@@ -377,12 +378,13 @@ func (v *Verifier) verifyLibraryRoot(result *Result) error {
 			}
 			continue
 		}
-		if !library.IsYearDir(e.Name()) {
-			result.Inconsistent++
-			v.logger.Warn("unexpected directory in library root: %s (expected YYYY)", e.Name())
-			if v.cfg.FailFast {
-				return fmt.Errorf("unexpected directory in library root: %s", e.Name())
-			}
+		if library.IsYearDir(e.Name()) || e.Name() == "undated" {
+			continue
+		}
+		result.Inconsistent++
+		v.logger.Warn("unexpected directory in library root: %s (expected YYYY)", e.Name())
+		if v.cfg.FailFast {
+			return fmt.Errorf("unexpected directory in library root: %s", e.Name())
 		}
 	}
 

--- a/internal/verifier/verifier_test.go
+++ b/internal/verifier/verifier_test.go
@@ -774,6 +774,39 @@ func TestVerifyLibraryRootUnexpectedDir(t *testing.T) {
 	assert.Equal(t, 1, result.Inconsistent)
 }
 
+// TestVerifyUndatedRootAllowed: undated/ at vault root with arbitrary freeform
+// content is accepted without warning, even with FailFast=true.
+func TestVerifyUndatedRootAllowed(t *testing.T) {
+	libDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(libDir, "2024", "sources"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(libDir, "undated", "loose-folder"), 0o755))
+	createTestFile(t, filepath.Join(libDir, "undated", "anything.jpg"), "data")
+	createTestFile(t, filepath.Join(libDir, "undated", "loose-folder", "nested.txt"), "data")
+
+	v, err := New(Config{LibraryPath: libDir, HashAlgo: "md5", FailFast: true}, &fakeExtractor{}, newTestLogger())
+	require.NoError(t, err)
+
+	result, err := v.Verify()
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Inconsistent)
+}
+
+// TestVerifyUndatedRootCoexistsWithUnexpected: undated/ does not mask warnings
+// from other unknown root directories.
+func TestVerifyUndatedRootCoexistsWithUnexpected(t *testing.T) {
+	libDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(libDir, "2024", "sources"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(libDir, "undated"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(libDir, "random"), 0o755))
+
+	v, err := New(Config{LibraryPath: libDir, HashAlgo: "md5", FailFast: false}, &fakeExtractor{}, newTestLogger())
+	require.NoError(t, err)
+
+	result, err := v.Verify()
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Inconsistent)
+}
+
 func TestVerifyYearLevelUnexpectedEntries(t *testing.T) {
 	libDir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(libDir, "2024", "sources"), 0o755))


### PR DESCRIPTION
## Summary
- Allow an optional freeform `undated/` directory at the vault root for media that has no usable year (or that the user doesn't want filed by year).
- `verify` no longer warns on `undated/` and does not recurse into it. Other unknown root entries still warn as before.
- Documented in `README.md` and `docs/superpowers/specs/2026-04-26-undated-root-dir-design.md`.

Implementation is one tweak to `verifyLibraryRoot` in `internal/verifier/verifier.go`. `import` and other commands are unchanged — `undated/` is populated manually.

## Test plan
- [x] `go test ./...` — all packages pass
- [x] `make lint` — 0 issues
- [x] New `TestVerifyUndatedRootAllowed`: `undated/` with arbitrary content + `FailFast=true` → `Inconsistent==0`
- [x] New `TestVerifyUndatedRootCoexistsWithUnexpected`: `undated/` alongside another non-year dir → only the other dir warns
- [x] Existing `TestVerifyLibraryRootUnexpectedDir` still warns on a generic non-year dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)